### PR TITLE
Add output directory option to `archive extract`

### DIFF
--- a/UnityDataTool.Tests/UnityDataToolTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolTests.cs
@@ -18,7 +18,7 @@ public class UnityDataToolTests : AssetBundleTestFixture
     public UnityDataToolTests(Context context) : base(context)
     {
     }
-    
+
     protected override void OnLoadExpectedData(Context context)
     {
         // Uncomment to regenerate expected data.
@@ -41,7 +41,7 @@ public class UnityDataToolTests : AssetBundleTestFixture
             file.Delete();
         }
     }
-        
+
     [Test]
     public void ArchiveExtract_FilesExtractedSuccessfully()
     {
@@ -197,7 +197,7 @@ public class UnityDataToolTests : AssetBundleTestFixture
         using (var cmd = db.CreateCommand())
         {
             cmd.CommandText =
-                @"SELECT 
+                @"SELECT
                     (SELECT COUNT(*) FROM animation_clips),
                     (SELECT COUNT(*) FROM asset_bundles),
                     (SELECT COUNT(*) FROM assets),
@@ -259,7 +259,7 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
             file.Delete();
         }
     }
-    
+
     [Test]
     public void Analyze_PlayerData_DatabaseCorrect()
     {
@@ -267,13 +267,13 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
         var analyzePath = Path.Combine(Context.UnityDataFolder);
 
         Assert.AreEqual(0, Program.Main(new string[] { "analyze", analyzePath, "-r" }));
-        
+
         using var db = new SQLiteConnection($"Data Source={databasePath};Version=3;New=True;Foreign Keys=False;");
         db.Open();
         using var cmd = db.CreateCommand();
 
         cmd.CommandText =
-            @"SELECT 
+            @"SELECT
                 (SELECT COUNT(*) FROM asset_bundles),
                 (SELECT COUNT(*) FROM assets),
                 (SELECT COUNT(*) FROM objects),
@@ -290,7 +290,7 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
         Assert.Greater(reader.GetInt32(3), 0);
         Assert.AreEqual(1, reader.GetInt32(4));
     }
-    
+
     [Test]
     public void DumpText_PlayerData_TextFileCreatedCorrectly()
     {

--- a/UnityDataTool.Tests/UnityDataToolTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolTests.cs
@@ -43,14 +43,15 @@ public class UnityDataToolTests : AssetBundleTestFixture
     }
 
     [Test]
-    public void ArchiveExtract_FilesExtractedSuccessfully()
+    public void ArchiveExtract_FilesExtractedSuccessfully(
+        [Values("", "-o archive", "--output-path archive")] string options)
     {
         var path = Path.Combine(Context.UnityDataFolder, "assetbundle");
 
-        Assert.AreEqual(0, Program.Main(new string[] { "archive", "extract", path }));
-        Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "CAB-5d40f7cad7c871cf2ad2af19ac542994")));
-        Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "CAB-5d40f7cad7c871cf2ad2af19ac542994.resS")));
-        Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "CAB-5d40f7cad7c871cf2ad2af19ac542994.resource")));
+        Assert.AreEqual(0, Program.Main(new string[] { "archive", "extract", path }.Concat(options.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray()));
+        Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "archive", "CAB-5d40f7cad7c871cf2ad2af19ac542994")));
+        Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "archive", "CAB-5d40f7cad7c871cf2ad2af19ac542994.resS")));
+        Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "archive", "CAB-5d40f7cad7c871cf2ad2af19ac542994.resource")));
     }
 
     [Test]

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -86,15 +86,17 @@ public static class Program
 
         {
             var pathArg = new Argument<FileInfo>("filename", "The path of the archive file").ExistingOnly();
+            var oOpt = new Option<DirectoryInfo>(aliases: new[] { "--output-path", "-o" }, description: "Output directory of the extracted archive", getDefaultValue: () => new DirectoryInfo("archive"));
 
             var extractArchiveCommand = new Command("extract", "Extract the archive.")
             {
                 pathArg,
+                oOpt,
             };
 
             extractArchiveCommand.SetHandler(
-                (FileInfo fi) => HandleExtractArchive(fi),
-                pathArg);
+                (FileInfo fi, DirectoryInfo o) => HandleExtractArchive(fi, o),
+                pathArg, oOpt);
 
             var listArchiveCommand = new Command("list", "List the content of an archive.")
             {
@@ -167,7 +169,7 @@ public static class Program
         return 1;
     }
 
-    static int HandleExtractArchive(FileInfo filename)
+    static int HandleExtractArchive(FileInfo filename, DirectoryInfo outputFolder)
     {
         try
         {
@@ -175,7 +177,7 @@ public static class Program
             foreach (var node in archive.Nodes)
             {
                 Console.WriteLine($"Extracting {node.Path}...");
-                CopyFile("/" + node.Path, Path.GetFileName(node.Path));
+                CopyFile("/" + node.Path, $"{outputFolder}/{node.Path}");
             }
         }
         catch (NotSupportedException)
@@ -212,6 +214,8 @@ public static class Program
     static void CopyFile(string source, string dest)
     {
         using var sourceFile = UnityFileSystem.OpenFile(source);
+        // Create the containing directory if it doesn't exist.
+        Directory.CreateDirectory(Path.GetDirectoryName(dest));
         using var destFile = new FileStream(dest, FileMode.Create);
 
         const int blockSize = 256 * 1024;

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -177,7 +177,7 @@ public static class Program
             foreach (var node in archive.Nodes)
             {
                 Console.WriteLine($"Extracting {node.Path}...");
-                CopyFile("/" + node.Path, $"{outputFolder}/{node.Path}");
+                CopyFile("/" + node.Path, Path.Combine(outputFolder.FullName, node.Path));
             }
         }
         catch (NotSupportedException)

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -14,7 +14,7 @@ public static class Program
     public static int Main(string[] args)
     {
         UnityFileSystem.Init();
-            
+
         var rootCommand = new RootCommand();
 
         {
@@ -115,7 +115,7 @@ public static class Program
         }
 
         var r = rootCommand.Invoke(args);
-            
+
         UnityFileSystem.Cleanup();
 
         return r;
@@ -129,7 +129,7 @@ public static class Program
     static int HandleAnalyze(DirectoryInfo path, string outputFile, bool extractReferences, string searchPattern)
     {
         var analyzer = new AnalyzerTool();
-        
+
         return analyzer.Analyze(path.FullName, outputFile, searchPattern, extractReferences);
     }
 

--- a/UnityDataTool/README.md
+++ b/UnityDataTool/README.md
@@ -88,6 +88,7 @@ information about the content of the output file.**
 The archive command offers a set of archive-related sub-commands.
 
 **extract** This sub-command extracts the content of an archive. It takes the archive path as
-argument.
+argument and also provides the following option:
+* -o, --output-path \<path\>: Output directory of the extracted archive (default: archive)
 
 **list** This sub-command lists the content of an archive. It takes the archive path as argument.


### PR DESCRIPTION
Specifications:
* Optional arguments are added to `UnityDataTools archive extract` to set the output directory to <directory path>:
    * long form: `--output-path <directory path>`
    * short form: `-o <directory path>`
* If the directory specified doesn't exist, the tool should create it.
* If no output directory is specified, the tool should extract the archive to a directory called `archive` in the current directory.
* When extracting an archive, its internal file structure (i.e. subdirectories) should be preserved, not flattened.