### PR TITLE
Propagate exit code

### DIFF
--- a/UnityDataTool.Tests/UnityDataToolTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolTests.cs
@@ -44,6 +44,19 @@ public class UnityDataToolTests : AssetBundleTestFixture
     }
 
     [Test]
+    public async Task InvalidFile(
+        [Values(
+            new string[] {"archive", "extract"},
+            new string[] {"archive", "list"},
+            new string[] {"dump"}
+        )] string[] args)
+    {
+        var path = Path.Combine(Context.TestDataFolder, "invalidfile");
+        var command = args.Append(path);
+        Assert.AreNotEqual(0, await Program.Main(command.ToArray()));
+    }
+
+    [Test]
     public async Task ArchiveExtract_FilesExtractedSuccessfully(
         [Values("", "-o archive", "--output-path archive")] string options)
     {

--- a/UnityDataTool.Tests/UnityDataToolTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolTests.cs
@@ -3,6 +3,7 @@ using System.Data.SQLite;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using UnityDataTools.TestCommon;
 using UnityDataTools.FileSystem;
@@ -43,19 +44,19 @@ public class UnityDataToolTests : AssetBundleTestFixture
     }
 
     [Test]
-    public void ArchiveExtract_FilesExtractedSuccessfully(
+    public async Task ArchiveExtract_FilesExtractedSuccessfully(
         [Values("", "-o archive", "--output-path archive")] string options)
     {
         var path = Path.Combine(Context.UnityDataFolder, "assetbundle");
 
-        Assert.AreEqual(0, Program.Main(new string[] { "archive", "extract", path }.Concat(options.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray()));
+        Assert.AreEqual(0, await Program.Main(new string[] { "archive", "extract", path }.Concat(options.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray()));
         Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "archive", "CAB-5d40f7cad7c871cf2ad2af19ac542994")));
         Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "archive", "CAB-5d40f7cad7c871cf2ad2af19ac542994.resS")));
         Assert.IsTrue(File.Exists(Path.Combine(m_TestOutputFolder, "archive", "CAB-5d40f7cad7c871cf2ad2af19ac542994.resource")));
     }
 
     [Test]
-    public void ArchiveList_ListFilesCorrectly()
+    public async Task ArchiveList_ListFilesCorrectly()
     {
         var path = Path.Combine(Context.UnityDataFolder, "assetbundle");
 
@@ -64,7 +65,7 @@ public class UnityDataToolTests : AssetBundleTestFixture
         var currentOut = Console.Out;
         Console.SetOut(sw);
 
-        Assert.AreEqual(0, Program.Main(new string[] { "archive", "list", path }));
+        Assert.AreEqual(0, await Program.Main(new string[] { "archive", "list", path }));
 
         var lines = sw.ToString().Split(sw.NewLine);
 
@@ -84,13 +85,13 @@ public class UnityDataToolTests : AssetBundleTestFixture
     }
 
     [Test]
-    public void DumpText_DefaultArgs_TextFileCreatedCorrectly(
+    public async Task DumpText_DefaultArgs_TextFileCreatedCorrectly(
         [Values("", "-f text", "--output-format text")] string options)
     {
         var path = Path.Combine(Context.UnityDataFolder, "assetbundle");
         var outputFile = Path.Combine(m_TestOutputFolder, "CAB-5d40f7cad7c871cf2ad2af19ac542994.txt");
 
-        Assert.AreEqual(0, Program.Main(new string[] { "dump", path }.Concat(options.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray()));
+        Assert.AreEqual(0, await Program.Main(new string[] { "dump", path }.Concat(options.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray()));
         Assert.IsTrue(File.Exists(outputFile));
 
         var content = File.ReadAllText(outputFile);
@@ -104,13 +105,13 @@ public class UnityDataToolTests : AssetBundleTestFixture
     }
 
     [Test]
-    public void DumpText_SkipLargeArrays_TextFileCreatedCorrectly(
+    public async Task DumpText_SkipLargeArrays_TextFileCreatedCorrectly(
         [Values("-s", "--skip-large-arrays")] string options)
     {
         var path = Path.Combine(Context.UnityDataFolder, "assetbundle");
         var outputFile = Path.Combine(m_TestOutputFolder, "CAB-5d40f7cad7c871cf2ad2af19ac542994.txt");
 
-        Assert.AreEqual(0, Program.Main(new string[] { "dump", path }.Concat(options.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray()));
+        Assert.AreEqual(0, await Program.Main(new string[] { "dump", path }.Concat(options.Split(" ", StringSplitOptions.RemoveEmptyEntries)).ToArray()));
         Assert.IsTrue(File.Exists(outputFile));
 
         var content = File.ReadAllText(outputFile);
@@ -124,48 +125,48 @@ public class UnityDataToolTests : AssetBundleTestFixture
     }
 
     [Test]
-    public void Analyze_DefaultArgs_DatabaseCorrect()
+    public async Task Analyze_DefaultArgs_DatabaseCorrect()
     {
         var databasePath = Path.Combine(m_TestOutputFolder, "database.db");
         var analyzePath = Path.Combine(Context.UnityDataFolder);
 
-        Assert.AreEqual(0, Program.Main(new string[] { "analyze", analyzePath }));
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath }));
 
         ValidateDatabase(databasePath, false);
     }
 
     [Test]
-    public void Analyze_WithRefs_DatabaseCorrect(
+    public async Task Analyze_WithRefs_DatabaseCorrect(
         [Values("-r", "--extract-references")] string options)
     {
         var databasePath = Path.Combine(m_TestOutputFolder, "database.db");
         var analyzePath = Path.Combine(Context.UnityDataFolder);
 
-        Assert.AreEqual(0, Program.Main(new string[] { "analyze", analyzePath }.Concat(options.Split(" ")).ToArray()));
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath }.Concat(options.Split(" ")).ToArray()));
 
         ValidateDatabase(databasePath, true);
     }
 
     [Test]
-    public void Analyze_WithPattern_DatabaseCorrect(
+    public async Task Analyze_WithPattern_DatabaseCorrect(
         [Values("-p *.", "--search-pattern *.")] string options)
     {
         var databasePath = Path.Combine(m_TestOutputFolder, "database.db");
         var analyzePath = Path.Combine(Context.UnityDataFolder);
 
-        Assert.AreEqual(0, Program.Main(new string[] { "analyze", analyzePath }.Concat(options.Split(" ")).ToArray()));
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath }.Concat(options.Split(" ")).ToArray()));
 
         ValidateDatabase(databasePath, false);
     }
 
     [Test]
-    public void Analyze_WithPatternNoMatch_DatabaseEmpty(
+    public async Task Analyze_WithPatternNoMatch_DatabaseEmpty(
         [Values("-p *.x", "--search-pattern *.x")] string options)
     {
         var databasePath = Path.Combine(m_TestOutputFolder, "database.db");
         var analyzePath = Path.Combine(Context.UnityDataFolder);
 
-        Assert.AreEqual(0, Program.Main(new string[] { "analyze", analyzePath }.Concat(options.Split(" ")).ToArray()));
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath }.Concat(options.Split(" ")).ToArray()));
 
         using var db = new SQLiteConnection($"Data Source={databasePath};Version=3;New=True;Foreign Keys=False;");
         db.Open();
@@ -179,13 +180,13 @@ public class UnityDataToolTests : AssetBundleTestFixture
     }
 
     [Test]
-    public void Analyze_WithOutputFile_DatabaseCorrect(
+    public async Task Analyze_WithOutputFile_DatabaseCorrect(
         [Values("-o my_database", "--output-file my_database")] string options)
     {
         var databasePath = Path.Combine(m_TestOutputFolder, "my_database");
         var analyzePath = Path.Combine(Context.UnityDataFolder);
 
-        Assert.AreEqual(0, Program.Main(new string[] { "analyze", analyzePath }.Concat(options.Split(" ")).ToArray()));
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath }.Concat(options.Split(" ")).ToArray()));
 
         ValidateDatabase(databasePath, false);
     }
@@ -262,12 +263,12 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
     }
 
     [Test]
-    public void Analyze_PlayerData_DatabaseCorrect()
+    public async Task Analyze_PlayerData_DatabaseCorrect()
     {
         var databasePath = Path.Combine(m_TestOutputFolder, "database.db");
         var analyzePath = Path.Combine(Context.UnityDataFolder);
 
-        Assert.AreEqual(0, Program.Main(new string[] { "analyze", analyzePath, "-r" }));
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath, "-r" }));
 
         using var db = new SQLiteConnection($"Data Source={databasePath};Version=3;New=True;Foreign Keys=False;");
         db.Open();
@@ -293,12 +294,12 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
     }
 
     [Test]
-    public void DumpText_PlayerData_TextFileCreatedCorrectly()
+    public async Task DumpText_PlayerData_TextFileCreatedCorrectly()
     {
         var path = Path.Combine(Context.UnityDataFolder, "level0");
         var outputFile = Path.Combine(m_TestOutputFolder, "level0.txt");
 
-        Assert.AreEqual(0, Program.Main(new string[] { "dump", path }));
+        Assert.AreEqual(0, await Program.Main(new string[] { "dump", path }));
         Assert.IsTrue(File.Exists(outputFile));
 
         var content = File.ReadAllText(outputFile);

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.CommandLine;
 using System.IO;
+using System.Threading.Tasks;
 using UnityDataTools.Analyzer;
 using UnityDataTools.Analyzer.SQLite.Handlers;
 using UnityDataTools.ReferenceFinder;
@@ -11,7 +12,7 @@ namespace UnityDataTools.UnityDataTool;
 
 public static class Program
 {
-    public static int Main(string[] args)
+    public static async Task<int> Main(string[] args)
     {
         UnityFileSystem.Init();
 
@@ -33,7 +34,7 @@ public static class Program
 
             analyzeCommand.AddAlias("analyse");
             analyzeCommand.SetHandler(
-                (DirectoryInfo di, string o, bool r, string p) => HandleAnalyze(di, o, r, p),
+                (DirectoryInfo di, string o, bool r, string p) => Task.FromResult(HandleAnalyze(di, o, r, p)),
                 pathArg, oOpt, rOpt, pOpt);
 
             rootCommand.AddCommand(analyzeCommand);
@@ -58,7 +59,7 @@ public static class Program
             };
 
             findRefsCommand.SetHandler(
-                (FileInfo fi, string o, long? i, string n, string t, bool a) => HandleFindReferences(fi, o, i, n, t, a),
+                (FileInfo fi, string o, long? i, string n, string t, bool a) => Task.FromResult(HandleFindReferences(fi, o, i, n, t, a)),
                 pathArg, oOpt, iOpt, nOpt, tOpt, aOpt);
 
             rootCommand.Add(findRefsCommand);
@@ -78,7 +79,7 @@ public static class Program
                 oOpt,
             };
             dumpCommand.SetHandler(
-                (FileInfo fi, DumpFormat f, bool s, DirectoryInfo o) => HandleDump(fi, f, s, o),
+                (FileInfo fi, DumpFormat f, bool s, DirectoryInfo o) => Task.FromResult(HandleDump(fi, f, s, o)),
                 pathArg, fOpt, sOpt, oOpt);
 
             rootCommand.AddCommand(dumpCommand);
@@ -95,7 +96,7 @@ public static class Program
             };
 
             extractArchiveCommand.SetHandler(
-                (FileInfo fi, DirectoryInfo o) => HandleExtractArchive(fi, o),
+                (FileInfo fi, DirectoryInfo o) => Task.FromResult(HandleExtractArchive(fi, o)),
                 pathArg, oOpt);
 
             var listArchiveCommand = new Command("list", "List the content of an archive.")
@@ -104,7 +105,7 @@ public static class Program
             };
 
             listArchiveCommand.SetHandler(
-                (FileInfo fi) => HandleListArchive(fi),
+                (FileInfo fi) => Task.FromResult(HandleListArchive(fi)),
                 pathArg);
 
             var archiveCommand = new Command("archive", "Unity Archive (AssetBundle) functions.")
@@ -116,7 +117,7 @@ public static class Program
             rootCommand.AddCommand(archiveCommand);
         }
 
-        var r = rootCommand.Invoke(args);
+        var r = await rootCommand.InvokeAsync(args);
 
         UnityFileSystem.Cleanup();
 


### PR DESCRIPTION
Closes #10 

Use asynchronous overloads of `Command.SetHandler` to propagate function return codes back to `Main` (now also async) and add testing for nonzero exit codes on failure. The synchronous overloads ignore the return value of the handler function.