### PR TITLE
After each test, delete all files AND directories in test output folder

### DIFF
--- a/UnityDataTool.Tests/UnityDataToolTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolTests.cs
@@ -36,10 +36,11 @@ public class UnityDataToolTests : AssetBundleTestFixture
     [TearDown]
     public void Teardown()
     {
-        foreach (var file in new DirectoryInfo(m_TestOutputFolder).EnumerateFiles())
-        {
-            file.Delete();
-        }
+        var testDir = new DirectoryInfo(m_TestOutputFolder);
+        testDir.EnumerateFiles()
+            .ToList().ForEach(f => f.Delete());
+        testDir.EnumerateDirectories()
+            .ToList().ForEach(d => d.Delete(true));
     }
 
     [Test]


### PR DESCRIPTION
The current behavior is to delete only files, not directories. The `archive extract` command now creates a directory, so this cleanup is necessary to ensure test independence.