### PR TITLE
Set culture in tests to overcome tests failing due to local culture settings

### DIFF
--- a/UnityDataTool.Tests/GlobalSetup.cs
+++ b/UnityDataTool.Tests/GlobalSetup.cs
@@ -1,0 +1,18 @@
+using System.Globalization;
+using System.Threading;
+using NUnit.Framework;
+
+namespace UnityDataTools.UnityDataTool.Tests;
+
+[SetUpFixture]
+public class GlobalSetup
+{
+    [OneTimeSetUp]
+    public void RunBeforeAnyTests()
+    {
+        // Serialized test data is in en-US format. Ensure that the tests run in this culture to avoid formatting
+        // related false negatives.
+        // TODO: Fix test data to be culture agnostic.
+        Thread.CurrentThread.CurrentCulture = new CultureInfo("en-US");
+    }
+}


### PR DESCRIPTION
Persisted test data is currently using US format, and related asserts will fail on non-US systems. Setting culture overcomes this until test data, or asserts, can be made culture agnostic