### PR TITLE
Fix missing game object parameter on sharedAssets proccesing

### DIFF
--- a/Analyzer/SQLite/SQLiteWriter.cs
+++ b/Analyzer/SQLite/SQLiteWriter.cs
@@ -199,6 +199,7 @@ public class SQLiteWriter : IWriter
             if (relativePath.EndsWith(".sharedAssets"))
             {
                 m_AddObjectCommand.Transaction = transaction;
+                m_AddObjectCommand.Parameters["@game_object"].Value = ""; // There is no asscociated GameObject
                 m_AddObjectCommand.Parameters["@id"].Value = sceneId;
                 m_AddObjectCommand.Parameters["@object_id"].Value = 0;
                 m_AddObjectCommand.Parameters["@serialized_file"].Value = serializedFileId;


### PR DESCRIPTION
Fix residue issue from Sqlite library migration that only showed up on M1 (all tests already passed on Windows)