### PR TITLE
Improve Analyze documentation, small code fixes

### DIFF
--- a/Analyzer/PPtrAndCrcProcessor.cs
+++ b/Analyzer/PPtrAndCrcProcessor.cs
@@ -65,7 +65,7 @@ public class PPtrAndCrcProcessor : IDisposable
                 {
                     reader = new UnityFileReader(Path.Join(m_Folder, filename), 4 * 1024 * 1024);
                 }
-                catch (Exception e)
+                catch (Exception)
                 {
                     Console.Error.WriteLine();
                     Console.Error.WriteLine($"Error opening resource file {filename}");

--- a/Analyzer/README.md
+++ b/Analyzer/README.md
@@ -7,11 +7,11 @@ TypeTree to extract information about these objects (e.g. name, size, etc.)
 The most common use of this library is through the [analyze](../UnityDataTool/README.md#analyzeanalyse)
 command of the UnityDataTool.  This uses the Analyze library to generate a SQLite database.
 
-Once generated a tool such as the [DB Browser for SQLite](https://sqlitebrowser.org/), or the command line `sqlite3` tool, can be used to look at the content of the database.
+Once generated, a tool such as the [DB Browser for SQLite](https://sqlitebrowser.org/), or the command line `sqlite3` tool, can be used to look at the content of the database.
 
 # Example usage
 
-See [analyze-examples.md](../Documentation/analyze-examples.md) for some examples of how to use the SQLite output of the UnityDataTool Analyze command.
+See [this topic](../Documentation/analyze-examples.md) for examples of how to use the SQLite output of the UnityDataTool Analyze command.
 
 # DataBase Reference
 

--- a/Analyzer/README.md
+++ b/Analyzer/README.md
@@ -4,31 +4,8 @@ The Analyzer is a class library that can be used to analyze the content of Unity
 as AssetBundles and SerializedFiles. It iterates through all the serialized objects and uses the
 TypeTree to extract information about these objects (e.g. name, size, etc.)
 
-The extracted information is forwarded to an object implementing the [IWriter](./IWriter.cs)
-interface. The library provides the [SQLiteWriter](./SQLite/SQLiteWriter.cs) implementation that
-writes the data into a SQLite database.
-
-It is possible to extract type-specific properties using classes inheriting from the
-[SerializedObject](./SerializedObjects/SerializedObject.cs) class. The project already provides
-the most common SerializedObject implementations in the [SerializedObjects](./SerializedObjects)
-folder.
-
-# How to use the library
-
-The [AnalyzerTool](./AnalyzerTool.cs) class is the API entry point. The main method is called
-Analyze. It is currently hardcoded to write using the [SQLiteWriter](./SQLite/SQLiteWriter.cs),
-but it can easily be adapter to use another writer type. It takes four parameters:
-* path (string): path of the folder where the files to analyze are located. It will be searched
-  recursively.
-* databaseName (string): database filename, it will be overwritten if it already exists.
-* searchPattern (string): file search pattern (e.g. \*.bundle).
-* skipReferences (bool): determines if the CRC calculation and references (PPtrs) extraction must
-  skipped. This is faster, but the refs table will be empty and the duplicate assets won't be
-  accurate.
-Calling this method will create the SQLite output database and will recursively
-process the files matching the search pattern in the provided path. It will add a row in
-the 'objects' table for each serialized object. This table contain basic information such as the
-size and the name of the object (if it has one).
+The most common use of this library is through the [analyze](UnityDataTool/README.md#analyzeanalyse)
+command of the UnityDataTool.  This uses the Analyze library to generate a SQLite database.
 
 # How to use the database
 
@@ -178,3 +155,35 @@ stripping it won't make a big difference.
 This view lists all the shaders aggregated by name. The *instances* column indicates how many time
 the shader was found in the data files. It also provides the total size per shader and the list of
 AssetBundles in which they were found.
+
+
+# Advanced
+
+## Using the library
+
+The [AnalyzerTool](./AnalyzerTool.cs) class is the API entry point. The main method is called
+Analyze. It is currently hard coded to write using the [SQLiteWriter](./SQLite/SQLiteWriter.cs),
+but this approach could be extended to add support for other outputs.
+
+Calling this method will recursively process the files matching the search pattern in the provided
+path. It will add a row in the 'objects' table for each serialized object. This table contain basic
+information such as the size and the name of the object (if it has one).
+
+## Extending the Library
+
+The extracted information is forwarded to an object implementing the [IWriter](./IWriter.cs)
+interface. The library provides the [SQLiteWriter](./SQLite/SQLiteWriter.cs) implementation that
+writes the data into a SQLite database.
+
+The core properties that apply to all Unity Objects are extracted into the `objects` table.
+However much of the most useful Analyze functionality comes by virtue of the type-specific information that is extracted for
+important types like Meshes, Shaders, Texture2D and AnimationClips.  For example, when a Mesh object is encountered in a Serialized
+File, then rows are added to both the `objects` table and the `meshes` table.  The meshes table contains columns that only apply to Mesh objects, for example the number of vertices, indices, bones, and channels.  The `mesh_view` is a view that joins the `objects` table with the `meshes` table, so that you can see all the properties of a Mesh object in one place.
+
+Each supported Unity object type follows the same pattern:
+* A Handler class in the SQLite/Handlers (e.g. [MeshHandler.cs](./SQLite/Handler/MeshHandler.cs).
+* The registration of the handler in the m_Handlers dictionary in [SQLiteWriter.cs](./SQLite/SQLiteWriter.cs).
+* SQL statements defining extra tables and views associated with the type, e.g. [Mesh.sql](./SQLite/Resources/Mesh.sql).
+* A Reader class that uses RandomAccessReader to read properties from the serialized object. e.g. [Mesh.cs](./SerializedObjects/Mesh.cs).
+
+It would be possible to extend the Analyze library to add additional columns for the existing types, or by following the same pattern to add additional types.  The [dump](UnityDataTool/README.md#dump) feature of UnityDataTool is a useful way to see the property names and other details of the serialization for a type.  Based on that information, code in the Reader class can use the RandomAccessReader to retrieve those properties to bring them into the SQLite database.

--- a/Analyzer/README.md
+++ b/Analyzer/README.md
@@ -4,14 +4,20 @@ The Analyzer is a class library that can be used to analyze the content of Unity
 as AssetBundles and SerializedFiles. It iterates through all the serialized objects and uses the
 TypeTree to extract information about these objects (e.g. name, size, etc.)
 
-The most common use of this library is through the [analyze](UnityDataTool/README.md#analyzeanalyse)
+The most common use of this library is through the [analyze](../UnityDataTool/README.md#analyzeanalyse)
 command of the UnityDataTool.  This uses the Analyze library to generate a SQLite database.
 
-# How to use the database
+Once generated a tool such as the [DB Browser for SQLite](https://sqlitebrowser.org/), or the command line `sqlite3` tool, can be used to look at the content of the database.
 
-A tool such as the [DB Browser for SQLite](https://sqlitebrowser.org/) is required to look at the
-content of the database. The database provides different views that can be used to easily find the
-information you might need.
+# Example usage
+
+See [analyze-examples.md](../Documentation/analyze-examples.md) for some examples of how to use the SQLite output of the UnityDataTool Analyze command.
+
+# DataBase Reference
+
+The database provides different views.  The views join multiple tables together and often it is not necessary to write your own SQL queries to find the information you want, especially when you are using a visual SQLite tool.
+
+This section gives an overview of the main views.
 
 ## object_view
 
@@ -156,7 +162,6 @@ This view lists all the shaders aggregated by name. The *instances* column indic
 the shader was found in the data files. It also provides the total size per shader and the list of
 AssetBundles in which they were found.
 
-
 # Advanced
 
 ## Using the library
@@ -186,4 +191,4 @@ Each supported Unity object type follows the same pattern:
 * SQL statements defining extra tables and views associated with the type, e.g. [Mesh.sql](./SQLite/Resources/Mesh.sql).
 * A Reader class that uses RandomAccessReader to read properties from the serialized object. e.g. [Mesh.cs](./SerializedObjects/Mesh.cs).
 
-It would be possible to extend the Analyze library to add additional columns for the existing types, or by following the same pattern to add additional types.  The [dump](UnityDataTool/README.md#dump) feature of UnityDataTool is a useful way to see the property names and other details of the serialization for a type.  Based on that information, code in the Reader class can use the RandomAccessReader to retrieve those properties to bring them into the SQLite database.
+It would be possible to extend the Analyze library to add additional columns for the existing types, or by following the same pattern to add additional types.  The [dump](../UnityDataTool/README.md#dump) feature of UnityDataTool is a useful way to see the property names and other details of the serialization for a type.  Based on that information, code in the Reader class can use the RandomAccessReader to retrieve those properties to bring them into the SQLite database.

--- a/Analyzer/SQLite/SQLiteWriter.cs
+++ b/Analyzer/SQLite/SQLiteWriter.cs
@@ -23,7 +23,7 @@ public class SQLiteWriter : IWriter
     private Util.ObjectIdProvider m_ObjectIdProvider = new ();
 
     private Regex m_RegexSceneFile = new(@"BuildPlayer-([^\.]+)(?:\.sharedAssets)?");
-    
+
     // Used to map PPtr fileId to its corresponding serialized file id in the database.
     Dictionary<int, int> m_LocalToDbFileId = new ();
 
@@ -37,7 +37,7 @@ public class SQLiteWriter : IWriter
         { "AssetBundle", new AssetBundleHandler() },
         { "PreloadData", new PreloadDataHandler() },
     };
-    
+
     private SqliteConnection m_Database;
     private SqliteCommand m_AddReferenceCommand = new SqliteCommand();
     private SqliteCommand m_AddAssetBundleCommand = new SqliteCommand();
@@ -82,9 +82,9 @@ public class SQLiteWriter : IWriter
             // Console.WriteLine($"Connection state before init: {m_Database.State}");
             handler.Init(m_Database);
             // Console.WriteLine($"Connection state after init: {m_Database.State}");
-            
+
         }
-        
+
         CreateSQLiteCommands();
     }
 
@@ -94,7 +94,7 @@ public class SQLiteWriter : IWriter
         {
             throw new InvalidOperationException("SQLiteWriter.End called before SQLiteWriter.Begin");
         }
-        
+
         foreach (var handler in m_Handlers.Values)
         {
             handler.Finalize(m_Database);
@@ -125,7 +125,7 @@ public class SQLiteWriter : IWriter
         m_AddReferenceCommand.Parameters.Add("@referenced_object", SqliteType.Integer);
         m_AddReferenceCommand.Parameters.Add("@property_path", SqliteType.Text);
         m_AddReferenceCommand.Parameters.Add("@property_type", SqliteType.Text);
-        
+
         m_AddObjectCommand = m_Database.CreateCommand();
         m_AddObjectCommand.CommandText = "INSERT INTO objects (id, object_id, serialized_file, type, name, game_object, size, crc32) VALUES (@id, @object_id, @serialized_file, @type, @name, @game_object, @size, @crc32)";
         m_AddObjectCommand.Parameters.Add("@id", SqliteType.Integer);
@@ -154,7 +154,7 @@ public class SQLiteWriter : IWriter
         {
             throw new InvalidOperationException("SQLWriter.BeginAssetBundle called twice");
         }
-        
+
         m_CurrentAssetBundleId = m_NextAssetBundleId++;
         m_AddAssetBundleCommand.Parameters["@id"].Value = m_CurrentAssetBundleId;
         m_AddAssetBundleCommand.Parameters["@name"].Value = name;
@@ -171,7 +171,7 @@ public class SQLiteWriter : IWriter
 
         m_CurrentAssetBundleId = -1;
     }
-    
+
     public void WriteSerializedFile(string relativePath, string fullPath, string containingFolder)
     {
         using var sf = UnityFileSystem.OpenSerializedFile(fullPath);
@@ -188,8 +188,8 @@ public class SQLiteWriter : IWriter
         if (match.Success)
         {
             var sceneName = match.Groups[1].Value;
-            
-            // There is no Scene object in Unity (a Scene is the full content of a 
+
+            // There is no Scene object in Unity (a Scene is the full content of a
             // SerializedFile). We generate an object id using the name of the Scene
             // as SerializedFile name, and the object id 0.
             sceneId = m_ObjectIdProvider.GetId((m_SerializedFileIdProvider.GetId(sceneName), 0));
@@ -212,7 +212,7 @@ public class SQLiteWriter : IWriter
                 m_AddObjectCommand.ExecuteNonQuery();
             }
         }
-        
+
         m_LocalToDbFileId.Clear();
 
         Context ctx = new()
@@ -275,7 +275,7 @@ public class SQLiteWriter : IWriter
                 {
                     name = randomAccessReader["m_Name"].GetValue<string>();
                 }
-                
+
                 if (randomAccessReader.HasChild("m_GameObject"))
                 {
                     var pptr = randomAccessReader["m_GameObject"];
@@ -316,7 +316,7 @@ public class SQLiteWriter : IWriter
 
             transaction.Commit();
         }
-        catch (Exception e)
+        catch (Exception)
         {
             transaction.Rollback();
             throw;

--- a/Analyzer/SerializedObjects/SerializedObject.cs
+++ b/Analyzer/SerializedObjects/SerializedObject.cs
@@ -1,9 +1,0 @@
-using UnityDataTools.FileSystem.TypeTreeReaders;
-
-namespace UnityDataTools.Analyzer.SerializedObjects;
-
-public abstract class SerializedObject
-{
-    protected SerializedObject() {}
-    protected SerializedObject(RandomAccessReader reader) {}
-}

--- a/Documentation/analyze-examples.md
+++ b/Documentation/analyze-examples.md
@@ -100,7 +100,7 @@ Note: Both MonoBehaviours and ScriptableObjects have the same serialized type "M
 
 The previous example shows how to find all MonoBehaviours and ScriptableObjects.  But you may want to filter this based on the actual scripting class.  This is a bit more involved than the previous examples, so lets first breakdown the approach.
 
-The serialized data for scipting class does not directly sort the class name, instead it stores a reference to a MonoScript.  The MonoScript in turn records the assembly, namespace and classname.
+The serialized data for scripting class does not directly sort the class name, instead it stores a reference to a MonoScript.  The MonoScript in turn records the assembly, namespace and classname.
 
 This is an example MonoScript from a `UnityDataTool dump` of a Serialized File:
 

--- a/Documentation/analyze-examples.md
+++ b/Documentation/analyze-examples.md
@@ -1,0 +1,77 @@
+# Example usage of Analyze
+
+This topic gives some examples of using the SQLite output of the UnityDataTools Analyze command.
+
+The command line arguments to invoke Analyze are documented [here](../UnityDataTool/README.md#analyzeanalyse).
+
+The tables and some internal details about how Analyze is implemented can be found [here](../Analyzer/README.md).
+
+Note: The examples in this topic assume that your database file is called `Analysis.db` and that is in your current working directory.
+
+## Command line configuration
+
+The examples assume you have `sqlite3` available in your path for your command prompt or terminal.
+
+On Windows, sqlite3.exe is available as part of the "SQLite command line tools", published from [www.sqlite.org|www.sqlite.org].
+
+## Example 1: Object Count
+
+To get the total number of objects in the build output run this command.
+
+```
+sqlite3 Analysis.db "SELECT COUNT(*) FROM objects;"
+```
+
+## Example 2: Shader keywords
+
+shader_view has a lot of useful information about shaders.  For example to see the list of keywords for a particular shader, try the following command.  This should work with both Powershell and Bash:
+```
+sqlite3 Analysis.db ".mode column" "SELECT keywords FROM shader_view WHERE name = 'Sprites/Default';"
+```
+
+Example output:
+
+```
+keywords
+-------------------
+PIXELSNAP_ON,
+INSTANCING_ON,
+ETC1_EXTERNAL_ALPHA
+```
+
+Another example query is the top 10 shaders by size.
+
+```
+sqlite3 Analysis.db ".mode column" "SELECT name, pretty_size, serialized_file FROM shader_view ORDER BY size DESC LIMIT 10;"
+```
+
+Example output (using a build of the [megacity-metro](https://github.com/Unity-Technologies/megacity-metro) project):
+```
+name                                        pretty_size  serialized_file
+------------------------------------------  -----------  --------------------------------
+TextMeshPro/Mobile/Distance Field           191.5 KB     resources.assets
+Hidden/Universal Render Pipeline/UberPost   144.3 KB     globalgamemanagers.assets
+Shader Graphs/CustomLightingBuildingsB_LOD  139.6 KB     1b2fdfe013c58ffd57d7663eb8db3e60
+Universal Render Pipeline/Lit               115.5 KB     1b2fdfe013c58ffd57d7663eb8db3e60
+Shader Graphs/CustomLightingBuildingsB      113.4 KB     1b2fdfe013c58ffd57d7663eb8db3e60
+Shader Graphs/CustomLightingBuildings        82.1 KB     1b2fdfe013c58ffd57d7663eb8db3e60
+Shader Graphs/IlluminatedSignsArray          71.7 KB     1b2fdfe013c58ffd57d7663eb8db3e60
+Shader Graphs/CustomLightingGlow             71.6 KB     1b2fdfe013c58ffd57d7663eb8db3e60
+TextMeshPro/Mobile/Distance Field            70.4 KB     resources.assets
+Shader Graphs/IlluminatedSigns               67.2 KB     1b2fdfe013c58ffd57d7663eb8db3e60
+```
+
+
+## Example: Using AI tools to help write queries
+
+This is not a tutorial on using AI tools.  However one useful tip:
+
+Many AI tools let you provide context by uploading a file or copying text.  They are helpful for crafting SQL statements and creating scripts.  However by default they probably do not know what to expect inside a UnityDataTools SQLite database.
+
+To provide this information you could run this command that dumps the current schema into a text file.
+
+```
+sqlite3 Analysis.db ".schema" > schema_dump.sql.txt
+```
+
+Then provide that file as context, prior to asking it to write queries based on the available tables, views and columns.  For example: *Help me write a command line calling sqlite3 for Analysis.db that will print the top 10 shaders by the size column.  It will print the name, pretty_size and serialized_file*

--- a/Documentation/analyze-examples.md
+++ b/Documentation/analyze-examples.md
@@ -16,7 +16,7 @@ However often it is useful to run queries from the command line, and to incorpor
 
 These examples assume you have `sqlite3` available in the path for your command prompt or terminal. On Windows that means that a directory containing `sqlite3.exe` is included in your PATH environmental variable.
 
-On Windows, sqlite3.exe is available as part of the "SQLite command line tools", published from [www.sqlite.org|www.sqlite.org].
+On Windows, sqlite3.exe is available as part of the "SQLite command line tools", published from [www.sqlite.org](www.sqlite.org).
 
 Note: Many of the examples in this topic assume that your database file is named `Analysis.db` in your current working directory.  
 
@@ -137,7 +137,7 @@ WHERE mb.type = 'MonoBehaviour'
   AND ms.name = 'ReferencedUnityObjects';
 ```
 
-## Example: Quick Summary for Individual AssetBundles
+## Example: Quick summary for individual AssetBundles
 
 Often Analyze is used for an entire build output, so that you can view information about the build output as a whole.
 However it can also be used in a more light weight fashion for quickly printing information about a specific AssetBundle.
@@ -216,10 +216,20 @@ object_id             type         name            pretty_size  crc32
 
 ## Example: Matching content back to the source asset
 
-UnityDataTool only works on the output of a Unity build, so it has no direct information about the originating project.  However, it is common to want to match content back to the original source asset or scene.
+UnityDataTool works on the output of a Unity build, which, by its very nature, only contains the crucial data needed to efficiently load built content in the Player.  So it does not include any information about the assets and scenes in the project that was used to create that build.  However you may want to match content back to the original source asset or scene.  For example if the size of an AssetBundle has unexpectedly changed between builds then you may want to track down which source assets could be responsible for that change.  Or you may want to confirm that some particular image has been included in the build.
 
 In many cases the source asset can be inferred based on your specific knowledge of your project, and how the build was configured.  For example the level files in a Player build match the Scenes in the Build Profile Scene list.  And the content of AssetBundles is driven from the assignment of specific assets to those AssetBundles (or Addressable groups).
 
-Also, in many cases the name of objects matches the file name of the asset.  For example the Texture2D "red" object probably comes from a file named red.png somewhere in the project.
+Also, in many cases the name of objects matches the file name of the asset.  For example the Texture2D "red" object probably comes from a file named red.png somewhere in the project.  
 
-For more precise information about how Source Assets contribute to the build result it may be better to consult the [BuildReport](https://docs.unity3d.com/ScriptReference/Build.Reporting.BuildReport.html) instead of using UnityDataTools.  The [BuildReportInspector](https://github.com/Unity-Technologies/BuildReportInspector) is a useful way to examine the BuildReport for Player and regular AssetBundle builds.  Addressable builds do not produce a BuildReport file, but there is similar reporting, for example the [Build Layout Report](https://docs.unity3d.com/Packages/com.unity.addressables@2.4/manual/BuildLayoutReport.html).
+Similarly, it may be possible to find an object based on a distinctive property values, such as a string or hash, by doing text-based searches in the output from the `dump` command.
+
+For more precise information about how Source Assets contribute to the build result it may be better to consult files that are produced during the build process, instead of UnityDataTools.
+
+Examples of alternative sources of build information:
+
+* The [BuildReport](https://docs.unity3d.com/ScriptReference/Build.Reporting.BuildReport.html) has detailed source information in the PackedAssets section.  The [BuildReportInspector](https://github.com/Unity-Technologies/BuildReportInspector) is a useful way to view data from the BuildReport.
+* The Editor log reports a lot of information during a build. 
+* Regular AssetBundle builds create [.manifest files](https://docs.unity3d.com/Manual/assetbundles-file-format.html), which contain information about the source assets and types.
+* Addressable builds do not produce BuildReport files, nor .manifest files. But there is similar reporting, for example the [Build Layout Report](https://docs.unity3d.com/Packages/com.unity.addressables@2.4/manual/BuildLayoutReport.html).
+

--- a/Documentation/analyze-examples.md
+++ b/Documentation/analyze-examples.md
@@ -12,15 +12,17 @@ You can find data in the SQLite database by running SQL queries.
 
 Graphical tools such as "DB Browser" offer a way to run these queries directly from the UI based on whatever database you have open.
 
-However often it is useful to run queries from the command line, and to incorporate queries into your scripts (bash, powershell, etc).  So some of the example on this page show the command line syntax for running simple queries.
+However often it is useful to run queries from the command line, and to incorporate queries into your scripts (bash, PowerShell, etc).  Some of the example on this page show the command line syntax for running simple queries.
 
 These examples assume you have `sqlite3` available in the path for your command prompt or terminal. On Windows that means that a directory containing `sqlite3.exe` is included in your PATH environmental variable.
 
 On Windows, sqlite3.exe is available as part of the "SQLite command line tools", published from [www.sqlite.org|www.sqlite.org].
 
-Note: The examples in this topic assume that your database file is called `Analysis.db`, and that is in your current working directory.
+Note: Many of the examples in this topic assume that your database file is named `Analysis.db` in your current working directory.  
 
-## Example: Object Count
+Disclaimer: The command line examples and scripts will need to be modified for your specific needs, and may need to be rewritten for your platform and preferred command line environment.  It is a best practice to only run commands that you fully understand from a command prompt.
+
+## Example: Object count
 
 Starting things simple: running the following command on a command prompt will invoke a query will print the total number of objects in the build.
 
@@ -28,7 +30,7 @@ Starting things simple: running the following command on a command prompt will i
 sqlite3 Analysis.db "SELECT COUNT(*) FROM objects;"
 ```
 
-## Example: Shader Information
+## Example: Shader information
 
 shader_view has a lot of useful information about shaders.  For example to see the list of keywords for a particular shader, try the following command.  This should work with both Powershell and Bash:
 ```
@@ -85,7 +87,7 @@ If you want to find out which AssetBundles in a build contain a certain object t
 sqlite3 Analysis.db "SELECT DISTINCT asset_bundle FROM object_view WHERE type = 'MonoBehaviour';"
 ```
 
-The above query takes advantage of the object_view which pulls together the data from multiple tables.  The equivalent query that works with the underlying tables directly would be the following:_
+The above query takes advantage of the object_view which pulls together the data from multiple tables.  The following query does exactly the same thing, but uses the underlying tables directly: 
 
 ```
 sqlite3 Analysis.db "SELECT DISTINCT ab.name AS asset_bundle FROM objects o INNER JOIN types t ON o.type = t.id INNER JOIN serialized_files sf ON o.serialized_file = sf.id LEFT JOIN asset_bundles ab ON sf.asset_bundle = ab.id WHERE t.name = 'MonoBehaviour';"
@@ -134,3 +136,90 @@ WHERE mb.type = 'MonoBehaviour'
   AND r.property_type = 'MonoScript'
   AND ms.name = 'ReferencedUnityObjects';
 ```
+
+## Example: Quick Summary for Individual AssetBundles
+
+Often Analyze is used for an entire build output, so that you can view information about the build output as a whole.
+However it can also be used in a more light weight fashion for quickly printing information about a specific AssetBundle.
+Typically the time to run analyze on a single file should be very fast, so it can be acceptable to use a temporary database and
+erase it immediately after that.
+
+This is an example if you want to look at an AssetBundle called sprites.bundle in the current working directory.
+
+```
+UnityDataTool analyze . -o sprites.bundle.db -p sprites.bundle
+sqlite3 .\sprites.bundle.db ".mode column" "SELECT object_id, type, name, pretty_size, crc32 from object_view"
+```
+
+After running this sprites.bundle.db is not needed anymore, and could be erased (e.g. using a platform/shell appropriate command like "del" or "rm").
+
+The following is an example PowerShell script that generalizes the idea:
+
+```
+# PowerShell Script to run UnityDataTool on a single AssetBundle (or single SerializedFile) and print out a summary of the objects.
+
+param(
+    [Parameter(Mandatory=$true)]
+    [string]$FileName
+)
+
+if (-not (Test-Path -Path $FileName)) {
+    Write-Error "File '$FileName' does not exist."
+    exit 1
+}
+
+#Query to run on the temporary analyze database
+$select_statement = "SELECT object_id, type, name, pretty_size, crc32 from object_view"
+
+# Separate the directory and file name
+$FileDir = Split-Path -Path $FileName -Parent
+$FileLeaf = Split-Path -Path $FileName -Leaf
+
+# If no directory is detected (relative file name), use the current working directory
+if (-not $FileDir) {
+    $FileDir = "."
+}
+
+# Retrieve the system's temp folder and create the temporary database file name
+$tempFolder = $env:TEMP
+$dbName = Join-Path -Path $tempFolder -ChildPath ("$FileLeaf.db")
+
+try {
+    # Run UnityDataTool
+    UnityDataTool analyze $FileDir -o $dbName -p $FileLeaf
+
+    # Query the database using sqlite3
+    sqlite3 $dbName ".mode column" $select_statement
+
+    # Delete the temporary database file
+    Remove-Item $dbName -Force
+} catch {
+    Write-Error "An error occurred: $_"
+}
+```
+
+Here is an example output from the script above (where the script has been saved as `objectlist.ps1` somewhere in the Path):
+
+```
+>objectlist.ps1 .\AssetBundles\sprites.bundle
+
+...
+
+object_id             type         name            pretty_size  crc32
+--------------------  -----------  --------------  -----------  ----------
+-3600607445234681765  Texture2D    red             148.5 KB     3115177070
+-2408881041259534328  Sprite       Snow            460.0 B      2324949527
+-1350043613627603771  Texture2D    Snow            512.2 KB     3894005184
+1                     AssetBundle  sprites.bundle  332.0 B      2353941696
+3866367853307903194   Sprite       red             460.0 B      1811343945
+```
+
+## Example: Matching content back to the source asset
+
+UnityDataTool only works on the output of a Unity build, so it has no direct information about the originating project.  However, it is common to want to match content back to the original source asset or scene.
+
+In many cases the source asset can be inferred based on your specific knowledge of your project, and how the build was configured.  For example the level files in a Player build match the Scenes in the Build Profile Scene list.  And the content of AssetBundles is driven from the assignment of specific assets to those AssetBundles (or Addressable groups).
+
+Also, in many cases the name of objects matches the file name of the asset.  For example the Texture2D "red" object probably comes from a file named red.png somewhere in the project.
+
+For more precise information about how Source Assets contribute to the build result it may be better to consult the [BuildReport](https://docs.unity3d.com/ScriptReference/Build.Reporting.BuildReport.html) instead of using UnityDataTools.  The [BuildReportInspector](https://github.com/Unity-Technologies/BuildReportInspector) is a useful way to examine the BuildReport for Player and regular AssetBundle builds.  Addressable builds do not produce a BuildReport file, but there is similar reporting, for example the [Build Layout Report](https://docs.unity3d.com/Packages/com.unity.addressables@2.4/manual/BuildLayoutReport.html).

--- a/Documentation/analyze-examples.md
+++ b/Documentation/analyze-examples.md
@@ -4,25 +4,31 @@ This topic gives some examples of using the SQLite output of the UnityDataTools 
 
 The command line arguments to invoke Analyze are documented [here](../UnityDataTool/README.md#analyzeanalyse).
 
-The tables and some internal details about how Analyze is implemented can be found [here](../Analyzer/README.md).
+The definition of the views, and some internal details about how Analyze is implemented, can be found [here](../Analyzer/README.md).
 
-Note: The examples in this topic assume that your database file is called `Analysis.db` and that is in your current working directory.
+## Running Queries from the Command line
 
-## Command line configuration
+You can find data in the SQLite database by running SQL queries.
 
-The examples assume you have `sqlite3` available in your path for your command prompt or terminal.
+Graphical tools such as "DB Browser" offer a way to run these queries directly from the UI based on whatever database you have open.
+
+However often it is useful to run queries from the command line, and to incorporate queries into your scripts (bash, powershell, etc).  So some of the example on this page show the command line syntax for running simple queries.
+
+These examples assume you have `sqlite3` available in the path for your command prompt or terminal. On Windows that means that a directory containing `sqlite3.exe` is included in your PATH environmental variable.
 
 On Windows, sqlite3.exe is available as part of the "SQLite command line tools", published from [www.sqlite.org|www.sqlite.org].
 
-## Example 1: Object Count
+Note: The examples in this topic assume that your database file is called `Analysis.db`, and that is in your current working directory.
 
-To get the total number of objects in the build output run this command.
+## Example: Object Count
+
+Starting things simple: running the following command on a command prompt will invoke a query will print the total number of objects in the build.
 
 ```
 sqlite3 Analysis.db "SELECT COUNT(*) FROM objects;"
 ```
 
-## Example 2: Shader keywords
+## Example: Shader Information
 
 shader_view has a lot of useful information about shaders.  For example to see the list of keywords for a particular shader, try the following command.  This should work with both Powershell and Bash:
 ```
@@ -39,13 +45,13 @@ INSTANCING_ON,
 ETC1_EXTERNAL_ALPHA
 ```
 
-Another example query is the top 10 shaders by size.
+Another example query is the top 5 shaders by size.
 
 ```
-sqlite3 Analysis.db ".mode column" "SELECT name, pretty_size, serialized_file FROM shader_view ORDER BY size DESC LIMIT 10;"
+sqlite3 Analysis.db ".mode column" "SELECT name, pretty_size, serialized_file FROM shader_view ORDER BY size DESC LIMIT 5;"
 ```
 
-Example output (using a build of the [megacity-metro](https://github.com/Unity-Technologies/megacity-metro) project):
+Example output (based on a build of the [megacity-metro](https://github.com/Unity-Technologies/megacity-metro) project):
 ```
 name                                        pretty_size  serialized_file
 ------------------------------------------  -----------  --------------------------------
@@ -54,11 +60,6 @@ Hidden/Universal Render Pipeline/UberPost   144.3 KB     globalgamemanagers.asse
 Shader Graphs/CustomLightingBuildingsB_LOD  139.6 KB     1b2fdfe013c58ffd57d7663eb8db3e60
 Universal Render Pipeline/Lit               115.5 KB     1b2fdfe013c58ffd57d7663eb8db3e60
 Shader Graphs/CustomLightingBuildingsB      113.4 KB     1b2fdfe013c58ffd57d7663eb8db3e60
-Shader Graphs/CustomLightingBuildings        82.1 KB     1b2fdfe013c58ffd57d7663eb8db3e60
-Shader Graphs/IlluminatedSignsArray          71.7 KB     1b2fdfe013c58ffd57d7663eb8db3e60
-Shader Graphs/CustomLightingGlow             71.6 KB     1b2fdfe013c58ffd57d7663eb8db3e60
-TextMeshPro/Mobile/Distance Field            70.4 KB     resources.assets
-Shader Graphs/IlluminatedSigns               67.2 KB     1b2fdfe013c58ffd57d7663eb8db3e60
 ```
 
 
@@ -74,4 +75,62 @@ To provide this information you could run this command that dumps the current sc
 sqlite3 Analysis.db ".schema" > schema_dump.sql.txt
 ```
 
-Then provide that file as context, prior to asking it to write queries based on the available tables, views and columns.  For example: *Help me write a command line calling sqlite3 for Analysis.db that will print the top 10 shaders by the size column.  It will print the name, pretty_size and serialized_file*
+Then provide that file as context, prior to asking it to write queries based on the available tables, views and columns.  For example: *Help me write a command line calling sqlite3 for Analysis.db that will print the top 5 shaders by the size column.  It will print the name, pretty_size and serialized_file.*
+
+## Example: Finding AssetBundles containing a certain object type
+
+If you want to find out which AssetBundles in a build contain a certain object type you can try a query like this:
+
+```
+sqlite3 Analysis.db "SELECT DISTINCT asset_bundle FROM object_view WHERE type = 'MonoBehaviour';"
+```
+
+The above query takes advantage of the object_view which pulls together the data from multiple tables.  The equivalent query that works with the underlying tables directly would be the following:_
+
+```
+sqlite3 Analysis.db "SELECT DISTINCT ab.name AS asset_bundle FROM objects o INNER JOIN types t ON o.type = t.id INNER JOIN serialized_files sf ON o.serialized_file = sf.id LEFT JOIN asset_bundles ab ON sf.asset_bundle = ab.id WHERE t.name = 'MonoBehaviour';"
+```
+
+Note: Both MonoBehaviours and ScriptableObjects have the same serialized type "MonoBehaviour".
+
+
+## Example: Finding instances of a scripting class
+
+The previous example shows how to find all MonoBehaviours and ScriptableObjects.  But you may want to filter this based on the actual scripting class.  This is a bit more involved than the previous examples, so lets first breakdown the approach.
+
+The serialized data for scipting class does not directly sort the class name, instead it stores a reference to a MonoScript.  The MonoScript in turn records the assembly, namespace and classname.
+
+This is an example MonoScript from a `UnityDataTool dump` of a Serialized File:
+
+```
+ID: -5763254701832525334 (ClassID: 115) MonoScript
+  m_Name (string) ReferencedUnityObjects
+  m_ExecutionOrder (int) 0
+  m_PropertiesHash (Hash128)
+  ...
+  m_ClassName (string) ReferencedUnityObjects
+  m_Namespace (string) Unity.Scenes
+  m_AssemblyName (string) Unity.Scenes
+```
+
+Currently UnityDataTool does implement custom handling for MonoScript objects, so we only have the m_Name field, which matches the m_ClassName field._ However so long as the class name is unique in your project this can be used to match against.
+
+For example to list all distinct class names in the build you can run this query
+
+```
+SELECT DISTINCT name FROM object_view WHERE type = 'MonoScript';
+```
+
+The actual scripting objects of that type may be spread all through your AssetBundles (or Player build).  To find them we need to make use of the `refs` table, which records the references from each object to other objects.  If we find each MonoBehaviour object that references the MonoScript with the desired class name then we have found all instances of that class.
+
+For example, to search for all instances of the class ReferencedUnityObjects we could run this query:
+
+```
+SELECT mb.asset_bundle, mb.serialized_file, mb.name, mb.object_id
+FROM object_view mb
+INNER JOIN refs r ON mb.id = r.object
+INNER JOIN objects ms ON r.referenced_object = ms.id
+WHERE mb.type = 'MonoBehaviour' 
+  AND r.property_type = 'MonoScript'
+  AND ms.name = 'ReferencedUnityObjects';
+```

--- a/README.md
+++ b/README.md
@@ -4,7 +4,9 @@ The UnityDataTool is a command line tool and showcase of the UnityFileSystemApi 
 The main purpose is for analysis of the content of Unity data files, for example AssetBundles and
 Player content.
 
-The [command line tool](./UnityDataTool/README.md) runs directly on Unity data files, without requiring the Editor to be running.  It covers functionality of the Unity tools WebExtract and binary2text, with better performance.  And it adds a lot of additional functionality, for example the ability to create a SQLite database for detailed analysis of build content.  It is designed to scale for large build outputs and has been used to fine-tune big Unity-based games.
+The [command line tool](./UnityDataTool/README.md) runs directly on Unity data files, without requiring the Editor to be running.  It covers functionality of the Unity tools WebExtract and binary2text, with better performance.  And it adds a lot of additional functionality, for example the ability to create a SQLite database for detailed analysis of build content (See [examples](./Documentation/analyze-examples.md) for more detail).
+
+It is designed to scale for large build outputs and has been used to fine-tune big Unity-based games.
 
 The command line tool uses the UnityFileSystemApi library to access the content of Unity Archives and Serialized files, which are Unity's primary binary formats. This repository also serves as a reference for how this library could be used as part of incorporating functionality into your own tools.
 


### PR DESCRIPTION
* Add a new topic to the documentation that gives some example usage of Analyze, for example to run queries on the command line.
* Rework the README.md for Analyze library to move the more advanced developer focused information to the bottom.  (I think most readers will just want to understand what Analyze does, and only more rare cases will they want to understand the implementation and actually extend library )
* Add more details about how to extend the Analyze library to add support for more types.

Trivial code changes:
* Remove dead code - SerializedObject base class is not used.
* Fix two warnings about unreferenced variables.