### PR TITLE
"Dump" command supports outputing a single object

### DIFF
--- a/Documentation/comparing-builds.md
+++ b/Documentation/comparing-builds.md
@@ -164,7 +164,7 @@ As expected, it's only fields on the MonoBehaviour and one of the Transforms tha
 
 In a normal case we would not know exactly what changed in the build, so rather than confirming the expected changes we probably would be working in the other direction - using comparison technique to see which objects and values changed and try to build an understanding of whether this is "expected" or not.
 
-Note: When you know the id of the object that has changed you can pass the `--object-id` argument to the `dump` command to only dump that object.  This can be useful for large Serialized Files with many objects, where you want to focus on changes to a single object.
+Note: When you know the id of the object that has changed you can pass the `--objectid` argument to the `dump` command to only dump that object.  This can be useful for large Serialized Files with many objects, where you want to focus on changes to a single object.
 
 # Example 2 - Changes in a texture
 

--- a/Documentation/comparing-builds.md
+++ b/Documentation/comparing-builds.md
@@ -164,6 +164,8 @@ As expected, it's only fields on the MonoBehaviour and one of the Transforms tha
 
 In a normal case we would not know exactly what changed in the build, so rather than confirming the expected changes we probably would be working in the other direction - using comparison technique to see which objects and values changed and try to build an understanding of whether this is "expected" or not.
 
+Note: When you know the id of the object that has changed you can pass the `--object-id` argument to the `dump` command to only dump that object.  This can be useful for large Serialized Files with many objects, where you want to focus on changes to a single object.
+
 # Example 2 - Changes in a texture
 
 The previous example covers the common case where the changes are limited to serialized values directly inside Serialized Files.  However its also common that data inside the auxiliary .resS and .resource files can change, based on changes to textures, meshes, audio or video.  This can also cause the AssetBundle content to change, even if the Serialized Files themselves are unchanged.

--- a/TextDumper/README.md
+++ b/TextDumper/README.md
@@ -5,11 +5,11 @@ file (AssetBundle or SerializedFile) into human-readable yaml-style text file.
 
 ## How to use
 
-The library consists of a single class called [TextDumperTool](./TextDumperTool.cs). It has a single 
-method named Dump and takes three parameters:
+The library consists of a single class called [TextDumperTool](./TextDumperTool.cs). It has a method named Dump and takes four parameters:
 * path (string): path of the data file.
 * outputPath (string): path where the output files will be created.
 * skipLargeArrays (bool): if true, the content of arrays larger than 1KB won't be dumped.
+* objectId (long, optional): if specified and not 0, only the object with this signed 64-bit id will be dumped. If 0 (default), all objects are dumped.
 
 ## How to interpret the output files
 

--- a/TextDumper/TextDumperTool.cs
+++ b/TextDumper/TextDumperTool.cs
@@ -22,6 +22,8 @@ public class TextDumperTool
         {
             try
             {
+                // Try the input as an unity archive, e.g. an AssetBundle
+                // In that case we dump each serialized file contained inside it.
                 using var archive = UnityFileSystem.MountArchive(path, "/");
                 foreach (var node in archive.Nodes)
                 {

--- a/TextDumper/TextDumperTool.cs
+++ b/TextDumper/TextDumperTool.cs
@@ -356,34 +356,23 @@ public class TextDumperTool
             }
             m_Writer.WriteLine();
 
-            if (objectId == 0)
+            bool dumpedObject = false;
+            foreach (var obj in m_SerializedFile.Objects)
             {
-                foreach (var obj in m_SerializedFile.Objects)
-                {
-                    var root = m_SerializedFile.GetTypeTreeRoot(obj.Id);
-                    var offset = obj.Offset;
+                if (objectId != 0 && obj.Id != objectId)
+                    continue;
 
-                    m_Writer.Write($"ID: {obj.Id} (ClassID: {obj.TypeId}) ");
-                    RecursiveDump(root, ref offset, 0);
-                    m_Writer.WriteLine();
-                }
+                var root = m_SerializedFile.GetTypeTreeRoot(obj.Id);
+                var offset = obj.Offset;
+
+                m_Writer.Write($"ID: {obj.Id} (ClassID: {obj.TypeId}) ");
+                RecursiveDump(root, ref offset, 0);
+                m_Writer.WriteLine();
+                dumpedObject = true;
             }
-            else
-            {
-                var obj = m_SerializedFile.Objects.FirstOrDefault(o => o.Id == objectId);
-                if (obj.Equals(default(ObjectInfo)))
-                {
-                    m_Writer.WriteLine($"Object with ID {objectId} not found.");
-                }
-                else
-                {
-                    var root = m_SerializedFile.GetTypeTreeRoot(obj.Id);
-                    var offset = obj.Offset;
-                    m_Writer.Write($"ID: {obj.Id} (ClassID: {obj.TypeId}) ");
-                    RecursiveDump(root, ref offset, 0);
-                    m_Writer.WriteLine();
-                }
-            }
+
+            if (objectId != 0 && !dumpedObject)
+                m_Writer.WriteLine($"Object with ID {objectId} not found.");
         }
     }
 

--- a/TextDumper/TextDumperTool.cs
+++ b/TextDumper/TextDumperTool.cs
@@ -1,6 +1,5 @@
 ﻿using System;
 using System.IO;
-using System.Linq;
 using System.Text;
 using UnityDataTools.FileSystem;
 
@@ -343,7 +342,7 @@ public class TextDumperTool
         return true;
     }
 
-    void OutputSerializedFile(string path, long objectId = 0)
+    void OutputSerializedFile(string path, long objectId)
     {
         using (m_Reader = new UnityFileReader(path, 64 * 1024 * 1024))
         using (m_SerializedFile = UnityFileSystem.OpenSerializedFile(path))

--- a/TextDumper/TextDumperTool.cs
+++ b/TextDumper/TextDumperTool.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.IO;
+using System.Linq;
 using System.Text;
 using UnityDataTools.FileSystem;
 
@@ -13,7 +14,7 @@ public class TextDumperTool
     SerializedFile m_SerializedFile;
     StreamWriter m_Writer;
 
-    public int Dump(string path, string outputPath, bool skipLargeArrays)
+    public int Dump(string path, string outputPath, bool skipLargeArrays, long objectId = 0)
     {
         m_SkipLargeArrays = skipLargeArrays;
 
@@ -30,7 +31,7 @@ public class TextDumperTool
                     {
                         using (m_Writer = new StreamWriter(Path.Combine(outputPath, Path.GetFileName(node.Path) + ".txt"), false))
                         {
-                            OutputSerializedFile("/" + node.Path);
+                            OutputSerializedFile("/" + node.Path, objectId);
                         }
                     }
                 }
@@ -40,7 +41,7 @@ public class TextDumperTool
                 // Try as SerializedFile
                 using (m_Writer = new StreamWriter(Path.Combine(outputPath, Path.GetFileName(path) + ".txt"), false))
                 {
-                    OutputSerializedFile(path);
+                    OutputSerializedFile(path, objectId);
                 }
             }
         }
@@ -340,7 +341,7 @@ public class TextDumperTool
         return true;
     }
 
-    void OutputSerializedFile(string path)
+    void OutputSerializedFile(string path, long objectId = 0)
     {
         using (m_Reader = new UnityFileReader(path, 64 * 1024 * 1024))
         using (m_SerializedFile = UnityFileSystem.OpenSerializedFile(path))
@@ -355,14 +356,33 @@ public class TextDumperTool
             }
             m_Writer.WriteLine();
 
-            foreach (var obj in m_SerializedFile.Objects)
+            if (objectId == 0)
             {
-                var root = m_SerializedFile.GetTypeTreeRoot(obj.Id);
-                var offset = obj.Offset;
+                foreach (var obj in m_SerializedFile.Objects)
+                {
+                    var root = m_SerializedFile.GetTypeTreeRoot(obj.Id);
+                    var offset = obj.Offset;
 
-                m_Writer.Write($"ID: {obj.Id} (ClassID: {obj.TypeId}) ");
-                RecursiveDump(root, ref offset, 0);
-                m_Writer.WriteLine();
+                    m_Writer.Write($"ID: {obj.Id} (ClassID: {obj.TypeId}) ");
+                    RecursiveDump(root, ref offset, 0);
+                    m_Writer.WriteLine();
+                }
+            }
+            else
+            {
+                var obj = m_SerializedFile.Objects.FirstOrDefault(o => o.Id == objectId);
+                if (obj.Equals(default(ObjectInfo)))
+                {
+                    m_Writer.WriteLine($"Object with ID {objectId} not found.");
+                }
+                else
+                {
+                    var root = m_SerializedFile.GetTypeTreeRoot(obj.Id);
+                    var offset = obj.Offset;
+                    m_Writer.Write($"ID: {obj.Id} (ClassID: {obj.TypeId}) ");
+                    RecursiveDump(root, ref offset, 0);
+                    m_Writer.WriteLine();
+                }
             }
         }
     }

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -75,6 +75,7 @@ public static class Program
             var fOpt = new Option<DumpFormat>(aliases: new[] { "--output-format", "-f" }, description: "Output format", getDefaultValue: () => DumpFormat.Text);
             var sOpt = new Option<bool>(aliases: new[] { "--skip-large-arrays", "-s" }, description: "Do not dump large arrays of basic data types");
             var oOpt = new Option<DirectoryInfo>(aliases: new[] { "--output-path", "-o"}, description: "Output folder", getDefaultValue: () => new DirectoryInfo(Environment.CurrentDirectory));
+            var objectIdOpt = new Option<long>(aliases: new[] { "--objectid", "-i" }, () => 0, "Only dump the object with this signed 64-bit id (default: 0, dump all objects)");
 
             var dumpCommand = new Command("dump", "Dump the contents of an AssetBundle or SerializedFile.")
             {
@@ -82,10 +83,11 @@ public static class Program
                 fOpt,
                 sOpt,
                 oOpt,
+                objectIdOpt,
             };
             dumpCommand.SetHandler(
-                (FileInfo fi, DumpFormat f, bool s, DirectoryInfo o) => Task.FromResult(HandleDump(fi, f, s, o)),
-                pathArg, fOpt, sOpt, oOpt);
+                (FileInfo fi, DumpFormat f, bool s, DirectoryInfo o, long objectId) => Task.FromResult(HandleDump(fi, f, s, o, objectId)),
+                pathArg, fOpt, sOpt, oOpt, objectIdOpt);
 
             rootCommand.AddCommand(dumpCommand);
         }
@@ -173,14 +175,14 @@ public static class Program
         }
     }
 
-    static int HandleDump(FileInfo filename, DumpFormat format, bool skipLargeArrays, DirectoryInfo outputFolder)
+    static int HandleDump(FileInfo filename, DumpFormat format, bool skipLargeArrays, DirectoryInfo outputFolder, long objectId = 0)
     {
         switch (format)
         {
             case DumpFormat.Text:
             {
                 var textDumper = new TextDumperTool();
-                return textDumper.Dump(filename.FullName, outputFolder.FullName, skipLargeArrays);
+                return textDumper.Dump(filename.FullName, outputFolder.FullName, skipLargeArrays, objectId);
             }
         }
 

--- a/UnityDataTool/README.md
+++ b/UnityDataTool/README.md
@@ -111,9 +111,10 @@ only supports the 'text' format, which is similar to the binary2text output form
 
 The command takes the path of the file to dump as argument. It also provides the following options:
 * -o, --output-path <output-path>  Output folder, default is the current folder.
-* -f, --output-format \<format\>: output format, default is 'text'.
+* -f, --output-format <format>: output format, default is 'text'.
 * -s, --skip-large-arrays: the contents of basic data type arrays with a large number of elements
   won't be dumped.
+* -i, --objectid <objectid>: only dump the object with this local file id. If not specified or 0, all objects will be dumped.
 
 Example: `UnityDataTool dump /path/to/file -o /path/to/output`
 


### PR DESCRIPTION
When writing the topic about comparing builds i realized that it could be useful to dump just a single object, especially because the dumps for large files can be many megabytes in size.

This is a little update to add an optional --objectid filter.  Copilot agent did a good job of the initial implementation but I adjusted the solution to something more to my taste and added more docs.  

I also tested it, including support for negative objectids.

Example:
```
UnityDataTool dump imagelist.bundle -i -8066222900050932585
```

produces a txt file that only shows object -8066222900050932585:

```
External References

ID: -8066222900050932585 (ClassID: 28) Texture2D
  m_Name (string) guineapig
  m_IsAlphaChannelOptional (bool) True
  m_Width (int) 1024
  m_Height (int) 1024
  m_CompleteImageSize (unsigned int) 699064
  m_MipsStripped (int) 0
  m_TextureFormat (int) 10
  m_MipCount (int) 11
  m_IsReadable (bool) False

```

Details:
* I thought of suppressing the ExternalReference dump in this case, but its possible that the object has an external reference and that table is important to understand those references.  So for the moment we always dump the External References (which can be empty as in the example above).

* When run on a Scene AssetBundle that has multiple serialized files it will simply apply the filter to each dump.

* For the moment i just added a quick mention in the comparing builds topic.  But the idea of this feature is to use it in scripts that will more directly pinpoint a change in an assetbundle, e.g. first figure out which objects changed using the approaches already demonstrated, then actually dump out those objects using the new feature and trigger some sort of diff.  I'm not certain the practical workflow for that given that some assetbundles might have a huge number of new/deleted/modified objects so as first step am just exposing the helpful low level functionality which can be useful even when run manually.
