### PR TITLE
Addressables BuildLayout.json Analyze fixes

### DIFF
--- a/Analyzer/SQLite/Parsers/Models/BuildLayout.cs
+++ b/Analyzer/SQLite/Parsers/Models/BuildLayout.cs
@@ -96,8 +96,8 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers.Models
         public ReferenceId[] InternalReferencedOtherAssets;
         public string[] Labels;
         public int MainAssetType;
-        public int StreamedSize;
-        public int SerializedSize;
+        public long StreamedSize;
+        public long SerializedSize;
         public string Name;
         public string CRC;
 
@@ -107,11 +107,11 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers.Models
         public ReferenceId[] BundleDependencies;
         public string Compression;
         public ReferenceId[] Dependencies;
-        public int DependencyFileSize;
+        public long DependencyFileSize;
         public ReferenceId[] DependentBundles;
         public ReferenceId[] ExpandedDependencies;
-        public int ExpandedDependencyFileSize;
-        public int FileSize;
+        public long ExpandedDependencyFileSize;
+        public long FileSize;
         public ReferenceId[] Files;
         public ReferenceId Group;
         public object Hash; // Complex object containing Hash and serializedVersion
@@ -131,9 +131,9 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers.Models
         public BundleObjectInfo BundleObjectInfo; // Object with Size property
         public ReferenceId[] ExternalReferences;
         public int MonoScriptCount;
-        public int MonoScriptSize;
+        public long MonoScriptSize;
         public ReferenceId[] OtherAssets;
-        public int PreloadInfoSize;
+        public long PreloadInfoSize;
         public ReferenceId[] SubFiles;
         public string WriteResultFilename;
 
@@ -148,7 +148,7 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers.Models
 
         // For BuildLayout/SubFile
         public bool IsSerializedFile;
-        public int Size;
+        public long Size;
     }
 
     public class ReferenceType
@@ -166,7 +166,7 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers.Models
 
     public class BundleObjectInfo
     {
-        public int Size;
+        public long Size;
     }
 
     public class AssetObject
@@ -175,7 +175,7 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers.Models
         public string ComponentName;
         public long LocalIdentifierInFile;
         public string ObjectName;
-        public int SerializedSize;
+        public long SerializedSize;
         public ObjectReference[] References; // Array of object references
         public int StreamedSize;
     }

--- a/Analyzer/SQLite/Writers/AddressablesBuildLayoutSQLWriter.cs
+++ b/Analyzer/SQLite/Writers/AddressablesBuildLayoutSQLWriter.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using Microsoft.Data.Sqlite;
 using Newtonsoft.Json;
@@ -245,11 +246,16 @@ namespace UnityDataTools.Analyzer.SQLite.Writers
             m_AddressablesBuildBundle.SetValue("result_type", reference.data.ResultType);
             m_AddressablesBuildBundle.ExecuteNonQuery();
 
+            var visited = new Dictionary<string, bool>();
             // Insert bundle dependencies
             if (reference.data.BundleDependencies != null)
             {
                 foreach (var dep in reference.data.BundleDependencies)
                 {
+                    var key = $"{buildId}_{reference.rid}_{dep.rid}";
+                    if (visited.ContainsKey(key))
+                        continue;
+                    visited.Add(key, true);
                     m_AddressablesBuildBundleDependency.SetTransaction(transaction);
                     m_AddressablesBuildBundleDependency.SetValue("bundle_id", reference.rid);
                     m_AddressablesBuildBundleDependency.SetValue("build_id", buildId);

--- a/UnityDataTool/UnityDataTool.csproj
+++ b/UnityDataTool/UnityDataTool.csproj
@@ -4,10 +4,10 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net9.0</TargetFramework>
     <LangVersion>latest</LangVersion>
-    <Version>1.3.0</Version>
-    <AssemblyVersion>1.3.0.0</AssemblyVersion>
-    <FileVersion>1.3.0.0</FileVersion>
-    <InformationalVersion>1.3.0</InformationalVersion>
+    <Version>1.3.1</Version>
+    <AssemblyVersion>1.3.1.0</AssemblyVersion>
+    <FileVersion>1.3.1.0</FileVersion>
+    <InformationalVersion>1.3.1</InformationalVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">


### PR DESCRIPTION
1. Fix for error when running analyze on the buildreport.json on a build that hit a size > 2GB.

E.g. an individual AssetBundle file was more than 2GB
As precautionary measure change all "size" fields to long (although most should be very hard to reach that limit)

2. Fix for UNIQUE constraint failed SQL error
Avoid adding the same dependency more than once.  This fixes errors discovered testing a large buildlayout.json