### PR TITLE
[#49] Improve analyze file specification, CLI help and docs improvements

### DIFF
--- a/Analyzer/AnalyzerTool.cs
+++ b/Analyzer/AnalyzerTool.cs
@@ -13,7 +13,7 @@ namespace UnityDataTools.Analyzer;
 
 public class AnalyzerTool
 {
-    bool m_Verbose = false;
+    AnalyzeOptions m_Options;
 
     public List<ISQLiteFileParser> parsers = new List<ISQLiteFileParser>()
     {
@@ -21,27 +21,31 @@ public class AnalyzerTool
         new SerializedFileParser(),
     };
 
-    public int Analyze(
-        string path,
-        string databaseName,
-        string searchPattern,
-        bool skipReferences,
-        bool skipCrc,
-        bool verbose,
-        bool noRecursion)
+    public class AnalyzeOptions
     {
-        m_Verbose = verbose;
+        public string Path { get; init; }
+        public string DatabaseName { get; init; }
+        public string SearchPattern { get; init; } = "*";
+        public bool SkipReferences { get; init; }
+        public bool SkipCrc { get; init; }
+        public bool Verbose { get; init; }
+        public bool NoRecursion { get; init; }
+    }
 
-        using SQLiteWriter writer = new(databaseName);
+    public int Analyze(AnalyzeOptions options)
+    {
+        m_Options = options;
+
+        using SQLiteWriter writer = new(m_Options.DatabaseName);
 
         try
         {
             writer.Begin();
             foreach (var parser in parsers)
             {
-                parser.Verbose = verbose;
-                parser.SkipReferences = skipReferences;
-                parser.SkipCrc = skipCrc;
+                parser.Verbose = m_Options.Verbose;
+                parser.SkipReferences = m_Options.SkipReferences;
+                parser.SkipCrc = m_Options.SkipCrc;
                 parser.Init(writer.Connection);
 
             }
@@ -56,9 +60,9 @@ public class AnalyzerTool
         timer.Start();
 
         var files = Directory.GetFiles(
-            path,
-            searchPattern,
-            noRecursion ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories);
+            m_Options.Path,
+            m_Options.SearchPattern,
+            m_Options.NoRecursion ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories);
 
         int countFailures = 0;
         int countSuccess = 0;
@@ -75,7 +79,7 @@ public class AnalyzerTool
                     try
                     {
                         parser.Parse(file);
-                        ReportProgress(Path.GetRelativePath(path, file), i, files.Length);
+                        ReportProgress(Path.GetRelativePath(m_Options.Path, file), i, files.Length);
                         countSuccess++;
                     }
                     catch (SerializedFileOpenException e)
@@ -83,7 +87,7 @@ public class AnalyzerTool
                         // Expected failure — the file content could not be parsed.
                         // Don't print a stack trace; it adds no value for this known failure mode.
                         EraseProgressLine();
-                        var relativePath = Path.GetRelativePath(path, file);
+                        var relativePath = Path.GetRelativePath(m_Options.Path, file);
                         Console.Error.WriteLine($"Failed to open: {relativePath}");
                         var hint = SerializedFileDetector.GetOpenFailureHint(e.FilePath);
                         if (hint != null)
@@ -94,9 +98,9 @@ public class AnalyzerTool
                     {
                         // Unexpected failure (SQL error, I/O error, bug, etc.) — print full details.
                         EraseProgressLine();
-                        var relativePath = Path.GetRelativePath(path, file);
+                        var relativePath = Path.GetRelativePath(m_Options.Path, file);
                         Console.Error.WriteLine($"Failed to process: {relativePath}");
-                        if (m_Verbose)
+                        if (m_Options.Verbose)
                         {
                             Console.Error.WriteLine($"  Exception: {e.GetType().Name}: {e.Message}");
                             if (e.InnerException != null)
@@ -109,9 +113,9 @@ public class AnalyzerTool
             }
             if (!foundParser)
             {
-                if (m_Verbose)
+                if (m_Options.Verbose)
                 {
-                    var relativePath = Path.GetRelativePath(path, file);
+                    var relativePath = Path.GetRelativePath(m_Options.Path, file);
                     Console.WriteLine();
                     Console.WriteLine($"Ignoring {relativePath}");
                 }
@@ -142,7 +146,7 @@ public class AnalyzerTool
     void ReportProgress(string relativePath, int fileIndex, int cntFiles)
     {
         var message = $"Processing {fileIndex * 100 / cntFiles}% ({fileIndex}/{cntFiles}) {relativePath}";
-        if (!m_Verbose)
+        if (!m_Options.Verbose)
         {
             EraseProgressLine();
             Console.Write($"\r{message}");
@@ -158,7 +162,7 @@ public class AnalyzerTool
 
     void EraseProgressLine()
     {
-        if (!m_Verbose)
+        if (!m_Options.Verbose)
             Console.Write($"\r{new string(' ', m_LastProgressMessageLength)}\r");
         else
             Console.WriteLine();

--- a/Analyzer/AnalyzerTool.cs
+++ b/Analyzer/AnalyzerTool.cs
@@ -23,7 +23,9 @@ public class AnalyzerTool
 
     public class AnalyzeOptions
     {
-        public string Path { get; init; }
+        // Each entry is a file or a directory. Directories are scanned using SearchPattern and
+        // NoRecursion; files are always included regardless of SearchPattern.
+        public IReadOnlyList<string> Paths { get; init; }
         public string DatabaseName { get; init; }
         public string SearchPattern { get; init; } = "*";
         public bool SkipReferences { get; init; }
@@ -59,17 +61,15 @@ public class AnalyzerTool
         var timer = new Stopwatch();
         timer.Start();
 
-        var files = Directory.GetFiles(
-            m_Options.Path,
-            m_Options.SearchPattern,
-            m_Options.NoRecursion ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories);
+        var files = CollectFiles();
 
         int countFailures = 0;
         int countSuccess = 0;
         int countIgnored = 0;
         int i = 1;
-        foreach (var file in files)
+        foreach (var (file, displayRoot) in files)
         {
+            var relativePath = Path.GetRelativePath(displayRoot, file);
             bool foundParser = false;
             foreach (var parser in parsers)
             {
@@ -79,7 +79,7 @@ public class AnalyzerTool
                     try
                     {
                         parser.Parse(file);
-                        ReportProgress(Path.GetRelativePath(m_Options.Path, file), i, files.Length);
+                        ReportProgress(relativePath, i, files.Count);
                         countSuccess++;
                     }
                     catch (SerializedFileOpenException e)
@@ -87,7 +87,6 @@ public class AnalyzerTool
                         // Expected failure — the file content could not be parsed.
                         // Don't print a stack trace; it adds no value for this known failure mode.
                         EraseProgressLine();
-                        var relativePath = Path.GetRelativePath(m_Options.Path, file);
                         Console.Error.WriteLine($"Failed to open: {relativePath}");
                         var hint = SerializedFileDetector.GetOpenFailureHint(e.FilePath);
                         if (hint != null)
@@ -98,7 +97,6 @@ public class AnalyzerTool
                     {
                         // Unexpected failure (SQL error, I/O error, bug, etc.) — print full details.
                         EraseProgressLine();
-                        var relativePath = Path.GetRelativePath(m_Options.Path, file);
                         Console.Error.WriteLine($"Failed to process: {relativePath}");
                         if (m_Options.Verbose)
                         {
@@ -115,7 +113,6 @@ public class AnalyzerTool
             {
                 if (m_Options.Verbose)
                 {
-                    var relativePath = Path.GetRelativePath(m_Options.Path, file);
                     Console.WriteLine();
                     Console.WriteLine($"Ignoring {relativePath}");
                 }
@@ -139,6 +136,40 @@ public class AnalyzerTool
         Console.WriteLine($"Total time: {(timer.Elapsed.TotalMilliseconds / 1000.0):F3} s");
 
         return 0;
+    }
+
+    // Expands the input paths into the concrete files to analyze. Each result pairs the file with the
+    // root used to render its relative path in progress/error messages: the scanned directory for files
+    // found by scanning, or the file's own directory for explicitly-named files. Duplicates reached via
+    // more than one input are analyzed once.
+    List<(string FullPath, string DisplayRoot)> CollectFiles()
+    {
+        var searchOption = m_Options.NoRecursion ? SearchOption.TopDirectoryOnly : SearchOption.AllDirectories;
+        var collected = new List<(string FullPath, string DisplayRoot)>();
+        var seen = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+        foreach (var inputPath in m_Options.Paths)
+        {
+            if (Directory.Exists(inputPath))
+            {
+                foreach (var file in Directory.GetFiles(inputPath, m_Options.SearchPattern, searchOption))
+                {
+                    if (seen.Add(Path.GetFullPath(file)))
+                        collected.Add((file, inputPath));
+                }
+            }
+            else if (File.Exists(inputPath))
+            {
+                if (seen.Add(Path.GetFullPath(inputPath)))
+                    collected.Add((inputPath, Path.GetDirectoryName(Path.GetFullPath(inputPath))));
+            }
+            else
+            {
+                Console.Error.WriteLine($"Warning: path not found, skipping: {inputPath}");
+            }
+        }
+
+        return collected;
     }
 
     int m_LastProgressMessageLength = 0;

--- a/Documentation/analyzer.md
+++ b/Documentation/analyzer.md
@@ -190,7 +190,7 @@ but this approach could be extended to add support for other outputs.
 
 Calling this method processes the provided paths, which can be individual files or directories.
 Directories are scanned recursively for files matching the search pattern (unless recursion is
-disabled). It will add a row in the 'objects' table for each serialized object. This table contain
+disabled). It will add a row in the 'objects' table for each serialized object. This table contains
 basic information such as the size and the name of the object (if it has one).
 
 ## Extending the Library

--- a/Documentation/analyzer.md
+++ b/Documentation/analyzer.md
@@ -188,9 +188,10 @@ The [AnalyzerTool](../Analyzer/AnalyzerTool.cs) class is the API entry point. Th
 Analyze. It is currently hard coded to write using the [SQLiteWriter](../Analyzer/SQLite/SQLiteWriter.cs),
 but this approach could be extended to add support for other outputs.
 
-Calling this method will recursively process the files matching the search pattern in the provided
-path. It will add a row in the 'objects' table for each serialized object. This table contain basic
-information such as the size and the name of the object (if it has one).
+Calling this method processes the provided paths, which can be individual files or directories.
+Directories are scanned recursively for files matching the search pattern (unless recursion is
+disabled). It will add a row in the 'objects' table for each serialized object. This table contain
+basic information such as the size and the name of the object (if it has one).
 
 ## Extending the Library
 

--- a/Documentation/buildreport.md
+++ b/Documentation/buildreport.md
@@ -49,7 +49,13 @@ SELECT build_time_asset_path from build_report_source_assets WHERE build_time_as
 
 ## Cross-Referencing with Build Output
 
-For comprehensive analysis, run `analyze` on both the build output **and** the matching build report file. Use a clean build to ensure PackedAssets information is fully populated. You may need to copy the build report into the build output directory so both are found by `analyze`.
+For comprehensive analysis, run `analyze` on both the build output **and** the matching build report file. Use a clean build to ensure PackedAssets information is fully populated.
+
+`analyze` accepts multiple path arguments, each of which can be a file or a directory, so you can pass the build output directory together with the build report path (or the directory containing it) in a single command:
+
+```bash
+UnityDataTool analyze /path/to/build/output /path/to/Library/LastBuild.buildreport
+```
 
 PackedAssets data provides source asset information for each object that isn't available when analyzing only the build output. Objects are listed in the same order as they appear in the output SerializedFile, .resS, or .resource file.
 
@@ -64,10 +70,32 @@ PackedAssets data provides source asset information for each object that isn't a
 
 ## Working with Multiple Build Reports
 
-Multiple build reports can be imported into the same database if their filenames differ. This enables:
+Multiple build reports can be imported into the same database if their filenames differ. Pass each report (and any build output directories) as separate path arguments to a single `analyze` command. This enables:
 - Comprehensive build history tracking
 - Cross-build comparisons
 - Identifying duplicated data between Player and AssetBundle builds
+
+### Prior to Unity 6.6
+
+Each build overwrites `Library/LastBuild.buildreport`. To compare builds, manually collect the report after each build, rename the copies so the filenames are unique (the analyzer keys serialized files by filename), then pass them to `analyze`:
+
+```bash
+UnityDataTool analyze build1.buildreport build2.buildreport
+```
+
+### Unity 6.6 and later
+
+Player and content directory builds record a structured [build history](https://docs.unity3d.com/6000.6/Documentation/ScriptReference/Build.BuildHistory.html) (default location `Library/BuildHistory`). Unity assigns each build its own directory and gives every build report a unique GUID-based filename, so there is no need to copy or rename reports to compare them. Run `analyze` on the entire build history folder, or on specific build report directories:
+
+```bash
+# Analyze every build in the history
+UnityDataTool analyze Library/BuildHistory
+
+# Analyze two specific builds
+UnityDataTool analyze Library/BuildHistory/20260504-153912Z-2dd7642e Library/BuildHistory/20260504-153855Z-7aff42f4
+```
+
+AssetBundle builds are not tracked in the build history; they still write only to `Library/LastBuild.buildreport`.
 
 See the schema sections below for guidance on writing queries that handle multiple build reports correctly.
 

--- a/Documentation/command-analyze.md
+++ b/Documentation/command-analyze.md
@@ -5,25 +5,39 @@ The `analyze` command extracts information from Unity Archives (e.g. AssetBundle
 ## Quick Reference
 
 ```
-UnityDataTool analyze <path> [options]
+UnityDataTool analyze <paths>... [options]
 ```
 
 | Option | Description | Default |
 |--------|-------------|---------|
-| `<path>` | Path to folder containing files to analyze | *(required)* |
+| `<paths>...` | One or more files or directories to analyze. Directories are scanned; files are analyzed directly. | *(required)* |
 | `-o, --output-file <file>` | Output database filename | `database.db` |
-| `-p, --search-pattern <pattern>` | File search pattern (`*` and `?` supported) | `*` |
+| `-p, --search-pattern <pattern>` | File search pattern applied when scanning directories (`*` and `?` supported) | `*` |
 | `-s, --skip-references` | Do not extract references (smaller DB, no `refs` table). CRC is still computed. | `false` |
 | `--skip-crc` | Skip the CRC32 checksum calculation (faster; `objects.crc32` will be 0) | `false` |
 | `-v, --verbose` | Show more information during analysis | `false` |
-| `--no-recurse` | Do not recurse into sub-directories | `false` |
+| `--no-recurse` | Do not recurse into sub-directories when scanning directories | `false` |
 | `-d, --typetree-data <file>` | Load an external TypeTree data file before processing (Unity 6.5+) | — |
+
+There is no way to append to an existing database, so every file you want in the results must be
+included in a single `analyze` invocation. Pass multiple paths to combine files from more than one
+location into the same database.
 
 ## Examples
 
 Analyze all files in a directory:
 ```bash
 UnityDataTool analyze /path/to/asset/bundles
+```
+
+Analyze a single file (no need for `.` plus `-p`):
+```bash
+UnityDataTool analyze /path/to/asset/bundles/my.bundle
+```
+
+Combine a build output directory with a build report file kept in a separate location:
+```bash
+UnityDataTool analyze /path/to/build/output /path/to/Library/LastBuild.buildreport
 ```
 
 Analyze only `.bundle` files and specify a custom database name:
@@ -42,7 +56,9 @@ See also [Analyze Examples](../../Documentation/analyze-examples.md).
 
 ## What Can Be Analyzed
 
-The analyze command works with the following types of directories:
+Each path may be an individual file or a directory. Directories are scanned (honoring
+`--search-pattern` and `--no-recurse`); individually-named files are always analyzed. The analyze
+command works with the following types of input:
 
 | Input Type | Description |
 |------------|-------------|

--- a/README.md
+++ b/README.md
@@ -40,17 +40,15 @@ Refer to the [commit history](https://github.com/Unity-Technologies/UnityDataToo
 
 ## Getting UnityFileSystemApi
 
-UnityFileSystemApi is distributed in the Tools folder of the Unity Editor (from version 2022.1.0a14). The UnityDataTools repository includes a Windows, Mac, and Linux copy of the library in the `UnityFileSystem/` directory. 
+UnityDataTool uses the native `UnityFileSystemApi` library to read Unity Archives and SerializedFiles. **Normally you don't need to do anything with this library.** The repository already includes a recent Windows, Mac, and Linux copy in the [`UnityFileSystem/`](https://github.com/Unity-Technologies/UnityDataTools/tree/main/UnityFileSystem) directory, and using that bundled copy is the recommended way to run the tool.
 
-The library is backward compatible and can read data files from most Unity versions, so typically the version that is provided with UnityDataTools can be used "as is".
+The library is backward compatible but not forward compatible: a given version can read content from the same or older Unity versions, but may be unable to read content produced by a newer Unity Editor than the library itself. The bundled copy is updated periodically as Unity evolves, so in practice it can read content from just about any Unity version.
 
-To analyze data using the library from a specific version of the Unity Editor, copy the appropriate UnityFileSystemApi file from your Unity Editor installation (`{UnityEditor}/Data/Tools/`) to `UnityDataTool/UnityFileSystem/` prior to building:
+`UnityFileSystemApi` is also distributed in the `Data/Tools/` folder of the Unity Editor (for all versions since 2022.1.0a14). In the rare case that you need to read content from a Unity version newer than the bundled library, copy the matching file from your Unity Editor installation (`{UnityEditor}/Data/Tools/`) into the `UnityFileSystem/` directory before building:
 
-The file name is as follows:
-
-- Windows: `UnityFileSystemApi.dll`
-- Mac: `UnityFileSystemApi.dylib`
-- Linux: `UnityFileSystemApi.so`
+- Windows: [`UnityFileSystemApi.dll`](https://github.com/Unity-Technologies/UnityDataTools/blob/main/UnityFileSystem/UnityFileSystemApi.dll)
+- Mac: [`UnityFileSystemApi.dylib`](https://github.com/Unity-Technologies/UnityDataTools/blob/main/UnityFileSystem/UnityFileSystemApi.dylib)
+- Linux: [`UnityFileSystemApi.so`](https://github.com/Unity-Technologies/UnityDataTools/blob/main/UnityFileSystem/UnityFileSystemApi.so)
 
 ## How to Build
 

--- a/UnityDataTool.Tests/BuildReportTests.cs
+++ b/UnityDataTool.Tests/BuildReportTests.cs
@@ -46,7 +46,7 @@ public class BuildReportTests
     {
         var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
 
-        var args = new List<string> { "analyze", m_TestDataFolder, "-p", "AssetBundle.buildreport" };
+        var args = new List<string> { "analyze", Path.Combine(m_TestDataFolder, "AssetBundle.buildreport") };
         if (skipReferences)
             args.Add("--skip-references");
 
@@ -159,7 +159,7 @@ public class BuildReportTests
     {
         var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
 
-        var args = new List<string> { "analyze", m_TestDataFolder, "-p", "AssetBundle.buildreport" };
+        var args = new List<string> { "analyze", Path.Combine(m_TestDataFolder, "AssetBundle.buildreport") };
         if (skipReferences)
             args.Add("--skip-references");
 
@@ -214,7 +214,7 @@ public class BuildReportTests
     {
         var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
 
-        var args = new List<string> { "analyze", m_TestDataFolder, "-p", "AssetBundle.buildreport" };
+        var args = new List<string> { "analyze", Path.Combine(m_TestDataFolder, "AssetBundle.buildreport") };
 
         Assert.AreEqual(0, await Program.Main(args.ToArray()));
         using var db = SQLTestHelper.OpenDatabase(databasePath);
@@ -246,7 +246,7 @@ public class BuildReportTests
     {
         var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
 
-        var args = new List<string> { "analyze", m_TestDataFolder, "-p", "Player.buildreport" };
+        var args = new List<string> { "analyze", Path.Combine(m_TestDataFolder, "Player.buildreport") };
 
         Assert.AreEqual(0, await Program.Main(args.ToArray()));
         using var db = SQLTestHelper.OpenDatabase(databasePath);
@@ -284,7 +284,7 @@ public class BuildReportTests
     {
         var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
 
-        var args = new List<string> { "analyze", m_TestDataFolder, "-p", "AssetBundle.buildreport" };
+        var args = new List<string> { "analyze", Path.Combine(m_TestDataFolder, "AssetBundle.buildreport") };
 
         Assert.AreEqual(0, await Program.Main(args.ToArray()));
         using var db = SQLTestHelper.OpenDatabase(databasePath);
@@ -344,13 +344,49 @@ public class BuildReportTests
             "Unexpected path in build_report_packed_assets_view");
     }
 
+    // The motivating case for issue #49: combine a scanned build-output directory with a build
+    // report file that lives in a separate location, all in a single analyze invocation.
+    [Test]
+    public async Task Analyze_DirectoryPlusExternalFile_BothIncluded()
+    {
+        var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
+
+        // Simulate a build output directory containing one report, with a second report kept elsewhere.
+        var buildOutputDir = Path.Combine(m_TestOutputFolder, "build_output");
+        Directory.CreateDirectory(buildOutputDir);
+        File.Copy(Path.Combine(m_TestDataFolder, "AssetBundle.buildreport"),
+            Path.Combine(buildOutputDir, "AssetBundle.buildreport"));
+
+        var args = new string[]
+        {
+            "analyze",
+            buildOutputDir,
+            Path.Combine(m_TestDataFolder, "Player.buildreport"),
+        };
+
+        Assert.AreEqual(0, await Program.Main(args));
+        using var db = SQLTestHelper.OpenDatabase(databasePath);
+
+        SQLTestHelper.AssertQueryInt(db, "SELECT COUNT(*) FROM build_reports", 2,
+            "Expected both the scanned directory's report and the external report");
+        SQLTestHelper.AssertQueryInt(db, "SELECT COUNT(*) FROM build_reports WHERE build_type = 'AssetBundle'", 1,
+            "Expected the AssetBundle report from the scanned directory");
+        SQLTestHelper.AssertQueryInt(db, "SELECT COUNT(*) FROM build_reports WHERE build_type = 'Player'", 1,
+            "Expected the Player report passed as an external file");
+    }
+
     [Test]
     public async Task Analyze_BuildReports_BothReports_ContainsBuildReportFilesData()
     {
         var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
 
-        // Analyze multiple BuildReports into the same database
-        var args = new List<string> { "analyze", m_TestDataFolder, "-p", "*.buildreport" };
+        // Analyze multiple BuildReports into the same database by passing each file explicitly.
+        var args = new List<string>
+        {
+            "analyze",
+            Path.Combine(m_TestDataFolder, "AssetBundle.buildreport"),
+            Path.Combine(m_TestDataFolder, "Player.buildreport"),
+        };
 
         Assert.AreEqual(0, await Program.Main(args.ToArray()));
         using var db = SQLTestHelper.OpenDatabase(databasePath);

--- a/UnityDataTool.Tests/SerializedFileCommandTests.cs
+++ b/UnityDataTool.Tests/SerializedFileCommandTests.cs
@@ -605,8 +605,8 @@ public class SerializedFileCommandTests
     {
         // First, run analyze command to create database
         var databasePath = Path.Combine(m_TestOutputFolder, "test_analyze.db");
-        var analyzePath = m_TestDataFolder;
-        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath, "-o", databasePath, "-p", "level0" }));
+        var analyzePath = Path.Combine(m_TestDataFolder, "level0");
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath, "-o", databasePath }));
 
         // Now run serialized-file objectlist
         var path = Path.Combine(m_TestDataFolder, "level0");

--- a/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
@@ -102,7 +102,7 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
             Console.SetError(swErr);
 
             // Analyze should return 0 even if files fail (non-zero would be a critical error)
-            Assert.AreEqual(0, await Program.Main(new string[] { "analyze", testDataFolder, "-p", "level0" }));
+            Assert.AreEqual(0, await Program.Main(new string[] { "analyze", Path.Combine(testDataFolder, "level0") }));
 
             var output = swOut.ToString() + swErr.ToString();
 

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -2,6 +2,7 @@ using System;
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.IO;
+using System.Reflection;
 using System.Threading.Tasks;
 using UnityDataTools.Analyzer;
 using UnityDataTools.FileSystem;
@@ -24,7 +25,7 @@ public static class Program
     {
         UnityFileSystem.Init();
 
-        var rootCommand = new RootCommand();
+        var rootCommand = new RootCommand(BuildRootDescription());
         rootCommand.AddCommand(BuildAnalyzeCommand());
         rootCommand.AddCommand(BuildFindRefsCommand());
         rootCommand.AddCommand(BuildDumpCommand());
@@ -36,6 +37,30 @@ public static class Program
         UnityFileSystem.Cleanup();
 
         return r;
+    }
+
+    const string DocumentationUrl = "https://github.com/Unity-Technologies/UnityDataTools/blob/main/Documentation/unitydatatool.md";
+
+    static string BuildRootDescription()
+    {
+        var version = Assembly.GetExecutingAssembly()
+            .GetCustomAttribute<AssemblyInformationalVersionAttribute>()?.InformationalVersion
+            ?? Assembly.GetExecutingAssembly().GetName().Version?.ToString()
+            ?? "unknown";
+
+        // Strip the SourceLink build-metadata suffix (e.g. "1.3.5+<commit>").
+        var plusIndex = version.IndexOf('+');
+        if (plusIndex >= 0)
+            version = version.Substring(0, plusIndex);
+
+        return
+            "UnityDataTool inspects and analyzes Unity file formats, for example the content formats for AssetBundles, " +
+            "Player and content directory builds. It can build a database of the Unity objects and their " +
+            "references for analysis, dump objects as text, and examine " +
+            "archive and SerializedFile internals.\n\n" +
+            "Run 'UnityDataTool [command] --help' for detailed help on a specific command.\n\n" +
+            $"Documentation: {DocumentationUrl}\n" +
+            $"Version: {version}";
     }
 
     static Command BuildAnalyzeCommand()

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -348,7 +348,16 @@ public static class Program
             Console.WriteLine("WARNING: --extract-references, -r option is deprecated (references are now extracted by default)");
         }
 
-        return analyzer.Analyze(path.FullName, outputFile, searchPattern, skipReferences, skipCrc, verbose, noRecurse);
+        return analyzer.Analyze(new AnalyzerTool.AnalyzeOptions
+        {
+            Path = path.FullName,
+            DatabaseName = outputFile,
+            SearchPattern = searchPattern,
+            SkipReferences = skipReferences,
+            SkipCrc = skipCrc,
+            Verbose = verbose,
+            NoRecursion = noRecurse,
+        });
     }
 
     static int HandleFindReferences(FileInfo databasePath, string outputFile, long? objectId, string objectName, string objectType, bool findAll)

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -65,17 +65,23 @@ public static class Program
 
     static Command BuildAnalyzeCommand()
     {
-        var pathArg = new Argument<DirectoryInfo>("path", "The path to the directory containing the files to analyze").ExistingOnly();
+        var pathArg = new Argument<FileSystemInfo[]>("paths",
+            "One or more files or directories to analyze. Directories are scanned (see --search-pattern and --no-recurse); "
+            + "files are analyzed directly. Combine paths to include files from multiple locations, e.g. a build output "
+            + "directory and a build report file.")
+        {
+            Arity = ArgumentArity.OneOrMore
+        }.ExistingOnly();
         var oOpt = new Option<string>(aliases: new[] { "--output-file", "-o" }, description: "Filename of the output database", getDefaultValue: () => "database.db");
-        var sOpt = new Option<bool>(aliases: new[] { "--skip-references", "-s" }, description: "Do not extract references (CRC is still computed unless --skip-crc is also given)");
+        var sOpt = new Option<bool>(aliases: new[] { "--skip-references", "-s" }, description: "Do not extract references");
         var scOpt = new Option<bool>(aliases: new[] { "--skip-crc" }, description: "Skip CRC checksum calculation");
         var rOpt = new Option<bool>(aliases: new[] { "--extract-references", "-r" }) { IsHidden = true };
-        var pOpt = new Option<string>(aliases: new[] { "--search-pattern", "-p" }, description: "File search pattern", getDefaultValue: () => "*");
+        var pOpt = new Option<string>(aliases: new[] { "--search-pattern", "-p" }, description: "File search pattern applied when scanning directories", getDefaultValue: () => "*");
         var vOpt = new Option<bool>(aliases: new[] { "--verbose", "-v" }, description: "Verbose output");
-        var recurseOpt = new Option<bool>(aliases: new[] { "--no-recurse" }, description: "Do not analyze contents of subdirectories inside path");
+        var recurseOpt = new Option<bool>(aliases: new[] { "--no-recurse" }, description: "Do not analyze contents of subdirectories inside scanned directories");
         var dOpt = new Option<FileInfo>(aliases: new[] { "--typetree-data", "-d" }, description: TypeTreeDataDescription);
 
-        var analyzeCommand = new Command("analyze", "Analyze AssetBundles or SerializedFiles.")
+        var analyzeCommand = new Command("analyze", "Analyze AssetBundles, SerializedFiles and build reports into a database.")
         {
             pathArg,
             oOpt,
@@ -332,7 +338,7 @@ public static class Program
     }
 
     static int HandleAnalyze(
-        DirectoryInfo path,
+        FileSystemInfo[] paths,
         string outputFile,
         bool skipReferences,
         bool skipCrc,
@@ -350,7 +356,7 @@ public static class Program
 
         return analyzer.Analyze(new AnalyzerTool.AnalyzeOptions
         {
-            Path = path.FullName,
+            Paths = Array.ConvertAll(paths, p => p.FullName),
             DatabaseName = outputFile,
             SearchPattern = searchPattern,
             SkipReferences = skipReferences,


### PR DESCRIPTION
## Summary

Primarily fixes #49 (improve how `analyze` specifies input files), plus a couple of related CLI/help and refactor improvements that were on this branch.

### `analyze` now takes multiple file or directory paths (#49)
The positional argument is now variadic — each path may be a **file or a directory**:

```bash
UnityDataTool analyze my.bundle                              # single file (no more ". -p my.bundle")
UnityDataTool analyze ./Build ./Library/LastBuild.buildreport   # build output + external build report
UnityDataTool analyze ./Build                               # unchanged
```

- Directories are scanned (honoring `--search-pattern` / `--no-recurse`); explicitly named files are analyzed directly.
- Multiple locations can be combined into one database in a single invocation (there is no way to append to an existing database).
- `AnalyzerTool.AnalyzeOptions.Paths` replaces the single `Path`; a new `CollectFiles()` expands inputs, dedups, and tracks per-input roots for relative-path display.

### CLI help improvements
- Root `--help` now has a description, the documentation URL, and the version number (read from the assembly).
- `AnalyzerTool.Analyze` refactored to take an options struct (matching `TextDumperTool`).

### Documentation
- `command-analyze.md`, `analyzer.md`: document the new multi-path usage.
- `buildreport.md`: cross-referencing build output + report, and the Unity 6.6 build history workflow.
- `README.md`: clarified the "Getting UnityFileSystemApi" section (bundled library normally needs no action; backward but not forward compatible; fixed copy path; hyperlinked the files).

## Testing
- Converted tests that used the awkward `". -p <file>"` form to pass file paths directly.
- Added coverage for the directory-plus-external-file case.
- Full `UnityDataTool.Tests` suite passes (212 tests).

Fixes #49