### PR TITLE
[#77] Detect missing TypeTrees up front in analyze and dump

### DIFF
--- a/Analyzer/AnalyzerTool.cs
+++ b/Analyzer/AnalyzerTool.cs
@@ -6,7 +6,6 @@ using UnityDataTools.Analyzer.SQLite.Handlers;
 using UnityDataTools.Analyzer.SQLite.Parsers;
 using UnityDataTools.Analyzer.SQLite.Writers;
 using UnityDataTools.Models;
-using UnityDataTools.BinaryFormat;
 using UnityDataTools.FileSystem;
 
 namespace UnityDataTools.Analyzer;
@@ -90,18 +89,14 @@ public class AnalyzerTool
                         // run can tell these apart from genuine failures.
                         EraseProgressLine();
                         Console.Error.WriteLine($"Skipped (no TypeTrees): {relativePath}");
-                        Console.Error.WriteLine(SerializedFileDetector.MissingTypeTreesHint);
                         countNoTypeTrees++;
                     }
-                    catch (SerializedFileOpenException e)
+                    catch (SerializedFileOpenException)
                     {
                         // Expected failure — the file content could not be parsed.
                         // Don't print a stack trace; it adds no value for this known failure mode.
                         EraseProgressLine();
                         Console.Error.WriteLine($"Failed to open: {relativePath}");
-                        var hint = SerializedFileDetector.GetOpenFailureHint(e.FilePath);
-                        if (hint != null)
-                            Console.Error.WriteLine(hint);
                         countFailures++;
                     }
                     catch (Exception e)

--- a/Analyzer/AnalyzerTool.cs
+++ b/Analyzer/AnalyzerTool.cs
@@ -66,6 +66,7 @@ public class AnalyzerTool
         int countFailures = 0;
         int countSuccess = 0;
         int countIgnored = 0;
+        int countNoTypeTrees = 0;
         int i = 1;
         foreach (var (file, displayRoot) in files)
         {
@@ -81,6 +82,16 @@ public class AnalyzerTool
                         parser.Parse(file);
                         ReportProgress(relativePath, i, files.Count);
                         countSuccess++;
+                    }
+                    catch (SerializedFileOpenException e) when (e.MissingTypeTrees)
+                    {
+                        // The file has no TypeTrees and was rejected before opening. This is an
+                        // expected, distinct outcome — reported and counted separately so a large
+                        // run can tell these apart from genuine failures.
+                        EraseProgressLine();
+                        Console.Error.WriteLine($"Skipped (no TypeTrees): {relativePath}");
+                        Console.Error.WriteLine(SerializedFileDetector.MissingTypeTreesHint);
+                        countNoTypeTrees++;
                     }
                     catch (SerializedFileOpenException e)
                     {
@@ -123,7 +134,7 @@ public class AnalyzerTool
         }
 
         Console.WriteLine();
-        Console.WriteLine($"Finalizing database. Successfully processed files: {countSuccess}, Failed files: {countFailures}, Ignored files: {countIgnored}");
+        Console.WriteLine($"Finalizing database. Successfully processed files: {countSuccess}, Failed files: {countFailures}, Files without TypeTrees: {countNoTypeTrees}, Ignored files: {countIgnored}");
 
         writer.End();
         foreach (var parser in parsers)

--- a/Analyzer/SQLite/Parsers/SerializedFileParser.cs
+++ b/Analyzer/SQLite/Parsers/SerializedFileParser.cs
@@ -105,7 +105,6 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers
                                 {
                                     // The file has no TypeTrees and was rejected before opening. This is
                                     // tracked separately so it isn't lumped with genuine processing errors.
-                                    // The hint is printed once per archive by the caller.
                                     archiveHadMissingTypeTrees = true;
                                 }
                                 catch (Exception e)

--- a/Analyzer/SQLite/Parsers/SerializedFileParser.cs
+++ b/Analyzer/SQLite/Parsers/SerializedFileParser.cs
@@ -81,6 +81,7 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers
             if (ArchiveDetector.IsUnityArchive(file))
             {
                 bool archiveHadErrors = false;
+                bool archiveHadMissingTypeTrees = false;
                 using (UnityArchive archive = UnityFileSystem.MountArchive(file, "archive:" + Path.DirectorySeparatorChar))
                 {
                     if (archive == null)
@@ -99,6 +100,13 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers
                                 try
                                 {
                                     m_Writer.WriteSerializedFile(node.Path, "archive:/" + node.Path, Path.GetDirectoryName(file));
+                                }
+                                catch (SerializedFileOpenException e) when (e.MissingTypeTrees)
+                                {
+                                    // The file has no TypeTrees and was rejected before opening. This is
+                                    // tracked separately so it isn't lumped with genuine processing errors.
+                                    // The hint is printed once per archive by the caller.
+                                    archiveHadMissingTypeTrees = true;
                                 }
                                 catch (Exception e)
                                 {
@@ -124,9 +132,15 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers
                     }
                 }
 
+                // Genuine errors take precedence over missing TypeTrees when reporting the archive's outcome.
                 if (archiveHadErrors)
                 {
                     throw new Exception("One or more files in the archive failed to process");
+                }
+
+                if (archiveHadMissingTypeTrees)
+                {
+                    throw new SerializedFileOpenException(file, missingTypeTrees: true);
                 }
             }
             else

--- a/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
+++ b/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
@@ -6,6 +6,7 @@ using Microsoft.Data.Sqlite;
 using UnityDataTools.Analyzer.SQLite.Commands.SerializedFile;
 using UnityDataTools.Analyzer.SQLite.Handlers;
 using UnityDataTools.Analyzer.Util;
+using UnityDataTools.BinaryFormat;
 using UnityDataTools.FileSystem;
 using UnityDataTools.FileSystem.TypeTreeReaders;
 
@@ -116,6 +117,16 @@ public class SerializedFileSQLiteWriter : IDisposable
 
     public void WriteSerializedFile(string relativePath, string fullPath, string containingFolder)
     {
+        // A file without TypeTrees can only be opened when its types exactly match this build of
+        // UnityFileSystemApi. Handing such a file to the native loader produces misleading version
+        // mismatch errors and can crash the process, so detect and reject it up front. The native
+        // VFS path here may be a real file or an entry inside a mounted archive.
+        using (var detectStream = new UnityFileStream(fullPath))
+        {
+            if (SerializedFileDetector.IsMissingTypeTrees(detectStream))
+                throw new SerializedFileOpenException(fullPath, missingTypeTrees: true);
+        }
+
         using var sf = UnityFileSystem.OpenSerializedFile(fullPath);
         using var reader = new UnityFileReader(fullPath, 64 * 1024 * 1024);
         using var pptrReader = new PPtrAndCrcProcessor(sf, reader, containingFolder, m_SkipCrc, AddReference);

--- a/TextDumper/TextDumperTool.cs
+++ b/TextDumper/TextDumperTool.cs
@@ -76,6 +76,9 @@ public class TextDumperTool
 
     int DumpSerializedFile()
     {
+        if (ReportIfMissingTypeTrees(m_Options.Path, m_Options.Path))
+            return 1;
+
         try
         {
             if (m_Options.ToStdout)
@@ -93,16 +96,25 @@ public class TextDumperTool
         }
         catch (SerializedFileOpenException)
         {
-            var hint = SerializedFileDetector.GetOpenFailureHint(m_Options.Path);
-            if (hint != null)
-            {
-                Console.Error.WriteLine();
-                Console.Error.WriteLine(hint);
-            }
+            Console.Error.WriteLine($"Error: Failed to open serialized file: {m_Options.Path}");
             return 1;
         }
 
         return 0;
+    }
+
+    // dump needs TypeTrees to interpret object data, so a SerializedFile without them cannot be dumped.
+    // Detecting this up front avoids handing the file to the native loader, which would otherwise emit
+    // misleading version mismatch errors or crash the process. Returns true (and prints a clear message)
+    // when the file has no TypeTrees. The path may be a real file or an entry in a mounted archive.
+    bool ReportIfMissingTypeTrees(string path, string displayName)
+    {
+        using var stream = new UnityFileStream(path);
+        if (!SerializedFileDetector.IsMissingTypeTrees(stream))
+            return false;
+
+        Console.Error.WriteLine($"Error: \"{displayName}\" has no TypeTrees. The dump command needs TypeTrees to interpret the serialized object data, so this file cannot be dumped.");
+        return true;
     }
 
     // For convenience we also support directly dumping serialized files that are inside an archive,
@@ -110,6 +122,7 @@ public class TextDumperTool
     int DumpArchive()
     {
         using var archive = UnityFileSystem.MountArchive(m_Options.Path, "/");
+        bool anyMissingTypeTrees = false;
 
         if (m_Options.ToStdout)
         {
@@ -139,6 +152,8 @@ public class TextDumperTool
 
             var node2 = singleSerializedFile.Value;
             Console.Error.WriteLine($"Processing {node2.Path} {node2.Size} {node2.Flags}");
+            if (ReportIfMissingTypeTrees("/" + node2.Path, node2.Path))
+                return 1;
             m_Writer = Console.Out;
             OutputSerializedFile("/" + node2.Path);
             m_Writer.Flush();
@@ -151,6 +166,12 @@ public class TextDumperTool
 
                 if (node.Flags.HasFlag(ArchiveNodeFlags.SerializedFile))
                 {
+                    if (ReportIfMissingTypeTrees("/" + node.Path, node.Path))
+                    {
+                        anyMissingTypeTrees = true;
+                        continue;
+                    }
+
                     using var writer = new StreamWriter(Path.Combine(m_Options.OutputPath, Path.GetFileName(node.Path) + ".txt"), false);
                     m_Writer = writer;
                     OutputSerializedFile("/" + node.Path);
@@ -158,7 +179,7 @@ public class TextDumperTool
             }
         }
 
-        return 0;
+        return anyMissingTypeTrees ? 1 : 0;
     }
 
     void OutputSerializedFile(string path)

--- a/UnityBinaryFormat/SerializedFileDetector.cs
+++ b/UnityBinaryFormat/SerializedFileDetector.cs
@@ -656,16 +656,6 @@ public static class SerializedFileDetector
     }
 
     /// <summary>
-    /// Explanation shown for SerializedFiles that have no TypeTrees. Such files can only be
-    /// opened when every type they use exactly matches the build of UnityFileSystemApi in use,
-    /// which is why the native loader reports misleading version mismatch errors (or crashes)
-    /// when that is not the case.
-    /// </summary>
-    public const string MissingTypeTreesHint =
-        "Note: This file does not have TypeTrees and can only be opened if all the " +
-        "types it uses exactly match the types in the build of UnityFileSystemApi being used.";
-
-    /// <summary>
     /// Returns true when the stream is a SerializedFile we can positively confirm has no TypeTrees.
     /// Returns false for files that have TypeTrees and for anything we cannot parse (so callers fall
     /// back to the normal open path rather than skipping a file we simply did not understand).
@@ -675,24 +665,6 @@ public static class SerializedFileDetector
         return TryDetectSerializedFile(stream, out var fileInfo)
             && TryParseMetadata(stream, fileInfo, out var metadata, out _, parseExtended: false)
             && !metadata.EnableTypeTree;
-    }
-
-    /// <summary>
-    /// Returns a diagnostic hint explaining why a SerializedFile may have failed to open,
-    /// or null if no specific diagnosis is available.
-    /// Currently detects the common case of missing TypeTrees (player builds compiled
-    /// without type information, which the DLL reports as a generic unknown error).
-    /// </summary>
-    /// <param name="path">Real filesystem path to the file that failed to open.</param>
-    public static string GetOpenFailureHint(string path)
-    {
-        if (TryDetectSerializedFile(path, out var fileInfo) &&
-            TryParseMetadata(path, fileInfo, out var metadata, out _) &&
-            !metadata.EnableTypeTree)
-        {
-            return MissingTypeTreesHint;
-        }
-        return null;
     }
 
     /// <summary>

--- a/UnityBinaryFormat/SerializedFileDetector.cs
+++ b/UnityBinaryFormat/SerializedFileDetector.cs
@@ -303,16 +303,37 @@ public static class SerializedFileDetector
         try
         {
             using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return TryDetectSerializedFile(stream, out info);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Stream-based variant of <see cref="TryDetectSerializedFile(string, out SerializedFileInfo)"/>.
+    /// Reads from the current contents of <paramref name="stream"/> (seeking it to the start first),
+    /// allowing detection of files that are not directly on disk (e.g. inside a mounted archive).
+    /// </summary>
+    public static bool TryDetectSerializedFile(Stream stream, out SerializedFileInfo info)
+    {
+        info = null;
+
+        try
+        {
             long fileLength = stream.Length;
 
             // Quick rejection: file must be at least large enough for the legacy header
             if (fileLength < LegacyHeaderSize)
                 return false;
 
+            stream.Seek(0, SeekOrigin.Begin);
+
             // Read enough bytes to cover a modern header (48 bytes)
             // We'll determine which format to parse based on the version field
             byte[] headerBytes = new byte[ModernHeaderSize];
-            int bytesRead = stream.Read(headerBytes, 0, headerBytes.Length);
+            int bytesRead = stream.ReadAtLeast(headerBytes, ModernHeaderSize, throwOnEndOfStream: false);
 
             if (bytesRead < LegacyHeaderSize)
                 return false;
@@ -528,11 +549,33 @@ public static class SerializedFileDetector
         metadata = null;
         errorMessage = null;
 
+        // The supported-version check depends only on the header, so do it before touching the file.
+        if (!IsMetadataVersionSupported(headerInfo.Version, out errorMessage))
+            return false;
+
+        try
+        {
+            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
+            return TryParseMetadata(stream, headerInfo, out metadata, out errorMessage);
+        }
+        catch
+        {
+            errorMessage = "An unexpected error occurred while opening the file.";
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Validates that the SerializedFile version is within the range whose metadata layout this
+    /// parser understands. Returns false with an explanatory message when it is not.
+    /// </summary>
+    private static bool IsMetadataVersionSupported(uint version, out string errorMessage)
+    {
         // Only support version >= 19 (Unity 2019.1). Older files have metadata format
         // differences we have not implemented.
-        if (headerInfo.Version < MinMetadataParseVersion)
+        if (version < MinMetadataParseVersion)
         {
-            errorMessage = $"Metadata parsing is not supported for SerializedFile version {headerInfo.Version}. " +
+            errorMessage = $"Metadata parsing is not supported for SerializedFile version {version}. " +
                            $"Version {MinMetadataParseVersion} (Unity 2019.1) or newer is required.";
             return false;
         }
@@ -540,20 +583,37 @@ public static class SerializedFileDetector
         // Reject versions beyond the highest known format. Future Unity versions may change the
         // metadata layout in ways that would cause incorrect results or a parse failure.
         // A newer version of UnityDataTool is required to read these files.
-        if (headerInfo.Version > MaxMetadataParseVersion)
+        if (version > MaxMetadataParseVersion)
         {
-            errorMessage = $"SerializedFile version {headerInfo.Version} is not supported. " +
+            errorMessage = $"SerializedFile version {version} is not supported. " +
                            $"UnityDataTool supports up to version {MaxMetadataParseVersion}. " +
                            $"Please use a newer version of UnityDataTool to read this file.";
             return false;
         }
+
+        errorMessage = null;
+        return true;
+    }
+
+    /// <summary>
+    /// Stream-based variant of <see cref="TryParseMetadata(string, SerializedFileInfo, out SerializedFileMetadata, out string)"/>.
+    /// When <paramref name="parseExtended"/> is false, only the leading metadata fields (Unity version,
+    /// target platform and EnableTypeTree) are read; the type/object/reference arrays are skipped. This
+    /// is the cheap path for callers that only need to know whether the file has TypeTrees.
+    /// </summary>
+    public static bool TryParseMetadata(Stream stream, SerializedFileInfo headerInfo, out SerializedFileMetadata metadata, out string errorMessage, bool parseExtended = true)
+    {
+        metadata = null;
+        errorMessage = null;
+
+        if (!IsMetadataVersionSupported(headerInfo.Version, out errorMessage))
+            return false;
 
         try
         {
             long metadataOffset = headerInfo.IsLegacyFormat ? LegacyHeaderSize : ModernHeaderSize;
             bool swap = headerInfo.Endianness == BigEndian;
 
-            using var stream = new FileStream(filePath, FileMode.Open, FileAccess.Read, FileShare.Read);
             stream.Seek(metadataOffset, SeekOrigin.Begin);
             using var reader = new BinaryReader(stream, System.Text.Encoding.ASCII, leaveOpen: true);
 
@@ -583,7 +643,8 @@ public static class SerializedFileDetector
 
             // Parse the rest of the metadata section. Protected by its own try/catch so that any
             // failure there still returns a partially-populated metadata struct.
-            ParseExtendedMetadata(reader, headerInfo, swap, metadataOffset, metadata);
+            if (parseExtended)
+                ParseExtendedMetadata(reader, headerInfo, swap, metadataOffset, metadata);
 
             return true;
         }
@@ -592,6 +653,28 @@ public static class SerializedFileDetector
             errorMessage = "An unexpected error occurred while parsing the metadata section.";
             return false;
         }
+    }
+
+    /// <summary>
+    /// Explanation shown for SerializedFiles that have no TypeTrees. Such files can only be
+    /// opened when every type they use exactly matches the build of UnityFileSystemApi in use,
+    /// which is why the native loader reports misleading version mismatch errors (or crashes)
+    /// when that is not the case.
+    /// </summary>
+    public const string MissingTypeTreesHint =
+        "Note: This file does not have TypeTrees and can only be opened if all the " +
+        "types it uses exactly match the types in the build of UnityFileSystemApi being used.";
+
+    /// <summary>
+    /// Returns true when the stream is a SerializedFile we can positively confirm has no TypeTrees.
+    /// Returns false for files that have TypeTrees and for anything we cannot parse (so callers fall
+    /// back to the normal open path rather than skipping a file we simply did not understand).
+    /// </summary>
+    public static bool IsMissingTypeTrees(Stream stream)
+    {
+        return TryDetectSerializedFile(stream, out var fileInfo)
+            && TryParseMetadata(stream, fileInfo, out var metadata, out _, parseExtended: false)
+            && !metadata.EnableTypeTree;
     }
 
     /// <summary>
@@ -607,8 +690,7 @@ public static class SerializedFileDetector
             TryParseMetadata(path, fileInfo, out var metadata, out _) &&
             !metadata.EnableTypeTree)
         {
-            return "Note: This file does not have TypeTrees and can only be opened if all the " +
-                   "types it uses exactly match the types in the build of UnityFileSystemApi being used.";
+            return MissingTypeTreesHint;
         }
         return null;
     }

--- a/UnityDataTool.Tests/DumpTests.cs
+++ b/UnityDataTool.Tests/DumpTests.cs
@@ -13,6 +13,8 @@ public class DumpTests
     private string m_SerializedFilePath;
     private string m_ResourceFilePath;
     private string m_MultiSerializedFileArchivePath;
+    private string m_NoTypeTreeSerializedFilePath;
+    private string m_NoTypeTreeArchivePath;
 
     [OneTimeSetUp]
     public void OneTimeSetup()
@@ -21,6 +23,8 @@ public class DumpTests
         m_SerializedFilePath = Path.Combine(m_TestDataFolder, "PlayerWithTypeTrees", "level0");
         m_ResourceFilePath = Path.Combine(m_TestDataFolder, "PlayerWithTypeTrees", "sharedassets0.assets.resS");
         m_MultiSerializedFileArchivePath = Path.Combine(m_TestDataFolder, "PlayerDataCompressed", "data.unity3d");
+        m_NoTypeTreeSerializedFilePath = Path.Combine(m_TestDataFolder, "PlayerNoTypeTree", "level0");
+        m_NoTypeTreeArchivePath = Path.Combine(m_TestDataFolder, "AssetBundleTypeTreeVariations", "AssetBundle-NoTypeTree", "small.bundle");
     }
 
     [Test]
@@ -206,5 +210,53 @@ public class DumpTests
         }
 
         Assert.That(swErr.ToString(), Does.Contain("does not appear to be a valid Unity SerializedFile or Unity Archive"));
+    }
+
+    [Test]
+    public async Task Dump_NoTypeTreeSerializedFile_ReportsMissingTypeTreesWithoutCrashing()
+    {
+        using var swOut = new StringWriter();
+        using var swErr = new StringWriter();
+        var currentOut = Console.Out;
+        var currentErr = Console.Error;
+        try
+        {
+            Console.SetOut(swOut);
+            Console.SetError(swErr);
+            Assert.AreNotEqual(0, await Program.Main(new string[] { "dump", m_NoTypeTreeSerializedFilePath, "--stdout" }));
+        }
+        finally
+        {
+            Console.SetOut(currentOut);
+            Console.SetError(currentErr);
+        }
+
+        var output = swOut.ToString() + swErr.ToString();
+        Assert.That(output, Does.Contain("has no TypeTrees"), "Expected a clear missing-TypeTrees message");
+        Assert.That(output, Does.Not.Contain("SerializedFileOpenException"), "Should not leak an exception/stack trace");
+    }
+
+    [Test]
+    public async Task Dump_NoTypeTreeArchive_ReportsMissingTypeTreesWithoutCrashing()
+    {
+        using var swOut = new StringWriter();
+        using var swErr = new StringWriter();
+        var currentOut = Console.Out;
+        var currentErr = Console.Error;
+        try
+        {
+            Console.SetOut(swOut);
+            Console.SetError(swErr);
+            Assert.AreNotEqual(0, await Program.Main(new string[] { "dump", m_NoTypeTreeArchivePath, "--stdout" }));
+        }
+        finally
+        {
+            Console.SetOut(currentOut);
+            Console.SetError(currentErr);
+        }
+
+        var output = swOut.ToString() + swErr.ToString();
+        Assert.That(output, Does.Contain("has no TypeTrees"), "Expected a clear missing-TypeTrees message");
+        Assert.That(output, Does.Not.Contain("SerializedFileOpenException"), "Should not leak an exception/stack trace");
     }
 }

--- a/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
@@ -145,7 +145,7 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
 
             var output = swOut.ToString() + swErr.ToString();
 
-            Assert.That(output, Does.Contain("does not have TypeTrees"), "Expected the missing-TypeTrees hint in output");
+            Assert.That(output, Does.Contain("Skipped (no TypeTrees)"), "Expected the file to be reported as skipped");
             Assert.That(output, Does.Contain("Files without TypeTrees: 1"), "Expected 'Files without TypeTrees: 1' in summary");
             Assert.That(output, Does.Contain("Successfully processed files: 0"), "Expected 'Successfully processed files: 0' in summary");
         }

--- a/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
@@ -89,7 +89,9 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
     [Test]
     public async Task Analyze_PlayerDataNoTypeTree_ReportsFailureCorrectly()
     {
-        // Test for issue #48: Files that fail to process should be counted as failures, not successes
+        // Test for issue #48: files that cannot be processed must not be counted as successes.
+        // Files without TypeTrees are detected up front and reported in their own summary category
+        // (rather than the generic failure count) so they can be told apart in a large run.
         var testDataFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "PlayerNoTypeTree");
 
         using var swOut = new StringWriter();
@@ -109,8 +111,42 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
             // Check that the filename appears in the error output
             Assert.That(output, Does.Contain("level0"), "Expected 'level0' to appear in error output");
 
-            // Check that the summary line correctly reports the failure
-            Assert.That(output, Does.Contain("Failed files: 1"), "Expected 'Failed files: 1' in summary");
+            // Check that the summary line categorizes the file as missing TypeTrees, not a success.
+            Assert.That(output, Does.Contain("Files without TypeTrees: 1"), "Expected 'Files without TypeTrees: 1' in summary");
+            Assert.That(output, Does.Contain("Successfully processed files: 0"), "Expected 'Successfully processed files: 0' in summary");
+        }
+        finally
+        {
+            Console.SetOut(currentOut);
+            Console.SetError(currentErr);
+        }
+    }
+
+    [Test]
+    public async Task Analyze_AssetBundleNoTypeTree_ReportsMissingTypeTreesWithoutCrashing()
+    {
+        // A no-TypeTree SerializedFile inside an archive must be detected up front and skipped
+        // cleanly. Handing it to the native loader otherwise emits misleading version mismatch
+        // errors and can crash the process with an access violation.
+        var bundlePath = Path.Combine(TestContext.CurrentContext.TestDirectory,
+            "Data", "AssetBundleTypeTreeVariations", "AssetBundle-NoTypeTree", "small.bundle");
+
+        using var swOut = new StringWriter();
+        using var swErr = new StringWriter();
+        var currentOut = Console.Out;
+        var currentErr = Console.Error;
+        try
+        {
+            Console.SetOut(swOut);
+            Console.SetError(swErr);
+
+            // Analyze should return 0 even when a bundle has no TypeTrees (no crash, no critical error).
+            Assert.AreEqual(0, await Program.Main(new string[] { "analyze", bundlePath }));
+
+            var output = swOut.ToString() + swErr.ToString();
+
+            Assert.That(output, Does.Contain("does not have TypeTrees"), "Expected the missing-TypeTrees hint in output");
+            Assert.That(output, Does.Contain("Files without TypeTrees: 1"), "Expected 'Files without TypeTrees: 1' in summary");
             Assert.That(output, Does.Contain("Successfully processed files: 0"), "Expected 'Successfully processed files: 0' in summary");
         }
         finally

--- a/UnityFileSystem/SerializedFileOpenException.cs
+++ b/UnityFileSystem/SerializedFileOpenException.cs
@@ -10,7 +10,19 @@ public class SerializedFileOpenException : Exception
 {
     public string FilePath { get; }
 
-    public SerializedFileOpenException(string filePath)
-        : base($"Failed to open serialized file: \"{filePath}\"")
-        => FilePath = filePath;
+    /// <summary>
+    /// True when the file was not opened because it has no TypeTrees. This is detected before
+    /// handing the file to the native loader, which would otherwise emit misleading version
+    /// mismatch errors or crash. Callers use it to report and count these files distinctly.
+    /// </summary>
+    public bool MissingTypeTrees { get; }
+
+    public SerializedFileOpenException(string filePath, bool missingTypeTrees = false)
+        : base(missingTypeTrees
+            ? $"Serialized file has no TypeTrees: \"{filePath}\""
+            : $"Failed to open serialized file: \"{filePath}\"")
+    {
+        FilePath = filePath;
+        MissingTypeTrees = missingTypeTrees;
+    }
 }

--- a/UnityFileSystem/UnityFileStream.cs
+++ b/UnityFileSystem/UnityFileStream.cs
@@ -1,0 +1,82 @@
+using System;
+using System.IO;
+
+namespace UnityDataTools.FileSystem;
+
+/// <summary>
+/// A read-only, seekable <see cref="Stream"/> over a <see cref="UnityFile"/>. This lets code that
+/// expects a standard Stream read from any path the native filesystem can open, including files
+/// inside a mounted archive (e.g. "archive:/CAB-...").
+/// </summary>
+public class UnityFileStream : Stream
+{
+    private readonly UnityFile m_File;
+    private readonly long m_Length;
+    private long m_Position;
+
+    public UnityFileStream(string path)
+    {
+        m_File = UnityFileSystem.OpenFile(path);
+        m_Length = m_File.GetSize();
+    }
+
+    public override bool CanRead => true;
+    public override bool CanSeek => true;
+    public override bool CanWrite => false;
+    public override long Length => m_Length;
+
+    public override long Position
+    {
+        get => m_Position;
+        set => Seek(value, System.IO.SeekOrigin.Begin);
+    }
+
+    public override int Read(byte[] buffer, int offset, int count)
+    {
+        if (count == 0 || m_Position >= m_Length)
+            return 0;
+
+        long toRead = Math.Min(count, m_Length - m_Position);
+
+        // UnityFile.Read always fills the destination buffer from index 0, so when the caller
+        // wants the data at a non-zero offset we read into a temporary buffer and copy it across.
+        byte[] dest = offset == 0 ? buffer : new byte[toRead];
+
+        m_File.Seek(m_Position);
+        long actual = m_File.Read(toRead, dest);
+
+        if (offset != 0)
+            Buffer.BlockCopy(dest, 0, buffer, offset, (int)actual);
+
+        m_Position += actual;
+        return (int)actual;
+    }
+
+    public override long Seek(long offset, System.IO.SeekOrigin origin)
+    {
+        long newPosition = origin switch
+        {
+            System.IO.SeekOrigin.Begin => offset,
+            System.IO.SeekOrigin.Current => m_Position + offset,
+            System.IO.SeekOrigin.End => m_Length + offset,
+            _ => throw new ArgumentOutOfRangeException(nameof(origin)),
+        };
+
+        if (newPosition < 0)
+            throw new IOException("Attempted to seek before the start of the stream.");
+
+        m_Position = newPosition;
+        return m_Position;
+    }
+
+    public override void Flush() { }
+    public override void SetLength(long value) => throw new NotSupportedException();
+    public override void Write(byte[] buffer, int offset, int count) => throw new NotSupportedException();
+
+    protected override void Dispose(bool disposing)
+    {
+        if (disposing)
+            m_File.Dispose();
+        base.Dispose(disposing);
+    }
+}


### PR DESCRIPTION
Fixes #77.

## Problem

Running `analyze` or `dump` on SerializedFiles without TypeTrees (e.g. player builds / AssetBundles built without type information) produced poor output:

1. **Misleading errors** — the native loader falls back to exact-version type matching when there are no TypeTrees, printing `Invalid serialized file version. Expected: ... Actual: ...` to stderr. The version mismatch is a symptom; the real cause is the missing TypeTrees.
2. **Process crash** — for some files the native DLL dereferenced bad memory and the whole process died with `Fatal error. 0xC0000005` plus a long managed stack trace. This is a native access violation that cannot be caught in .NET.

Loose `dump` failures additionally surfaced a raw `SerializedFileOpenException` with a stack trace, and the archive `dump` path had no clean handling at all.

## Fix

Detect missing TypeTrees **before** handing the file to the native loader (works for both loose files and entries inside a mounted archive), and handle the case cleanly. This pre-empts both the misleading stderr output and the crash, since the file is never opened natively.

- **`SerializedFileDetector`** — added stream-based overloads of `TryDetectSerializedFile`/`TryParseMetadata` (the path-based ones now delegate to them), a `parseExtended` flag so only the few bytes needed for the `EnableTypeTree` flag are read, and an `IsMissingTypeTrees(Stream)` helper.
- **`UnityFileStream`** (new) — a read/seek `Stream` over `UnityFile`, so detection works on real paths and `archive:/…` entries.
- **`analyze`** — rejects no-TypeTree files before opening and reports them in a new **`Files without TypeTrees`** summary category, distinct from genuine failures.
- **`dump`** — prints a clear message that it cannot dump a file without TypeTrees, for both the direct-file and archive paths.
- **`SerializedFileOpenException`** — gained a `MissingTypeTrees` flag.
- Removed the now-misleading "Note: ... can only be opened if all the types match" hint and the dead `GetOpenFailureHint`/`MissingTypeTreesHint` it relied on.

### Before / after (`analyze`)

```
# before: misleading version errors, then Fatal error 0xC0000005 + stack trace

# after:
Skipped (no TypeTrees): level0
...
Finalizing database. Successfully processed files: 0, Failed files: 0, Files without TypeTrees: 4, Ignored files: 2
```

### Before / after (`dump` on a no-TypeTree AssetBundle)

```
# before:
Invalid serialized file version. File: "/CAB-...". Expected version: 6000.5.0a8. Actual version: 6000.6.0a8.
Error: UnityDataTools.FileSystem.SerializedFileOpenException: Failed to open serialized file: "/CAB-..."
   at ... (long stack trace)

# after:
Processing CAB-... 17092 SerializedFile
Error: "CAB-..." has no TypeTrees. The dump command needs TypeTrees to interpret the serialized object data, so this file cannot be dumped.
```

## Testing

- Added analyze tests (loose + archive no-TypeTree) and dump tests (loose + archive no-TypeTree) asserting the clean messages, the new summary category, and no leaked stack trace.
- Verified normal analyze/dump (files with TypeTrees) still work.
- Full suite passes (702 tests).