### PR TITLE
Document project structure; split Archive and SerializedFile into their own libraries

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -90,13 +90,21 @@ UnityDataTool find-refs database.db -n "ObjectName" -t "Texture2D"
 
 ### Component Hierarchy
 ```
-UnityDataTool (CLI executable)
+UnityDataTool (CLI executable)  — wires the feature libraries into commands
 ├── Analyzer → SQLite database generation
 ├── TextDumper → Human-readable text output
-├── ReferenceFinder → Object reference chain tracing
-└── UnityFileSystem → C# wrapper for native library
-    └── UnityFileSystemApi (native .dll/.dylib/.so)
+├── ReferenceFinder → Object reference chain tracing (queries the Analyzer database)
+├── Archive → inspect / extract Unity Archives (the `archive` command)
+├── SerializedFile → inspect SerializedFile header/metadata/objects (the `serialized-file` command)
+└── (base libraries, used by the feature libraries above)
+    ├── UnityBinaryFormat → C# parsers & helpers for Archives / SerializedFiles
+    ├── UnityDataModels → schemas for JSON build-report formats
+    └── UnityFileSystem → C# wrapper for native library
+        └── UnityFileSystemApi (native .dll/.dylib/.so)
 ```
+
+The feature libraries each build on UnityBinaryFormat and UnityFileSystem. See the
+"Repository content" section of `README.md` for a diagram of the dependencies.
 
 ### Key Architectural Patterns
 

--- a/Archive/Archive.csproj
+++ b/Archive/Archive.csproj
@@ -1,0 +1,28 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ApplicationIcon />
+    <StartupObject />
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UnityBinaryFormat\UnityBinaryFormat.csproj" />
+    <ProjectReference Include="..\UnityFileSystem\UnityFileSystem.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/Archive/ArchiveTool.cs
+++ b/Archive/ArchiveTool.cs
@@ -5,10 +5,16 @@ using System.Text.Json;
 using UnityDataTools.BinaryFormat;
 using UnityDataTools.FileSystem;
 
-namespace UnityDataTools.UnityDataTool;
+namespace UnityDataTools.Archive;
 
-public static class Archive
+public static class ArchiveTool
 {
+    public enum OutputFormat
+    {
+        Text,
+        Json
+    }
+
     public static int HandleExtract(FileInfo filename, DirectoryInfo outputFolder, string filter = null)
     {
         try

--- a/Archive/ArchiveTool.cs
+++ b/Archive/ArchiveTool.cs
@@ -15,7 +15,7 @@ public static class ArchiveTool
         Json
     }
 
-    public static int HandleExtract(FileInfo filename, DirectoryInfo outputFolder, string filter = null)
+    public static int ExtractContent(FileInfo filename, DirectoryInfo outputFolder, string filter = null)
     {
         try
         {
@@ -45,7 +45,7 @@ public static class ArchiveTool
         return 0;
     }
 
-    public static int HandleList(FileInfo filename, OutputFormat format)
+    public static int ListContent(FileInfo filename, OutputFormat format)
     {
         try
         {
@@ -76,7 +76,7 @@ public static class ArchiveTool
         return 0;
     }
 
-    public static int HandleHeader(FileInfo filename, OutputFormat format)
+    public static int PrintHeader(FileInfo filename, OutputFormat format)
     {
         var path = filename.ToString();
 
@@ -100,7 +100,7 @@ public static class ArchiveTool
         return 0;
     }
 
-    public static int HandleBlocks(FileInfo filename, OutputFormat format)
+    public static int ListBlocks(FileInfo filename, OutputFormat format)
     {
         var path = filename.ToString();
 
@@ -130,7 +130,7 @@ public static class ArchiveTool
         return 0;
     }
 
-    public static int HandleInfo(FileInfo filename, OutputFormat format)
+    public static int PrintSummary(FileInfo filename, OutputFormat format)
     {
         var path = filename.ToString();
 

--- a/Archive/README.md
+++ b/Archive/README.md
@@ -1,0 +1,3 @@
+# Archive
+
+See [Documentation/command-archive.md](../Documentation/command-archive.md)

--- a/Archive/WebBundleHelper.cs
+++ b/Archive/WebBundleHelper.cs
@@ -6,7 +6,7 @@ using System.Linq;
 using System.Text;
 using System.Text.Json;
 
-namespace UnityDataTools.UnityDataTool;
+namespace UnityDataTools.Archive;
 
 public static class WebBundleHelper
 {
@@ -50,14 +50,14 @@ public static class WebBundleHelper
         Console.WriteLine($"Extracted {extracted} out of {total} files.");
     }
 
-    public static void List(FileInfo filename, OutputFormat format)
+    public static void List(FileInfo filename, ArchiveTool.OutputFormat format)
     {
         using var fileStream = File.Open(filename.ToString(), FileMode.Open);
         using var stream = GetStream(filename, fileStream);
         using var reader = new BinaryReader(stream, Encoding.UTF8);
         var fileDescriptions = ParseWebBundleHeader(reader);
 
-        if (format == OutputFormat.Json)
+        if (format == ArchiveTool.OutputFormat.Json)
         {
             var jsonArray = new object[fileDescriptions.Count];
             for (int i = 0; i < fileDescriptions.Count; i++)

--- a/README.md
+++ b/README.md
@@ -37,19 +37,76 @@ New to Unity's data files or to UnityDataTool? These topics are a good place to 
 
 ## Repository content
 
-The repository contains the following items:
-* [UnityDataTool](Documentation/unitydatatool.md): a command-line tool providing access to the Analyzer, TextDumper and other class libraries.
-* [Analyzer](Documentation/analyzer.md): a class library that can be used to extract key information
-  from Unity data files and output it into a SQLite database.
-* [TextDumper](Documentation/textdumper.md): a class library that can be used to dump SerializedFiles into
-  a human-readable format (similar to binary2text).
-* [ReferenceFinder](Documentation/referencefinder.md): a class library that can be used to find
-  reference chains from objects to other objects using a database created by the Analyzer
-* UnityFileSystem: source code and binaries of a .NET class library exposing the functionalities or the
-  UnityFileSystemApi native library.
-* UnityFileSystem.Tests: test suite for the UnityFileSystem library.
-* UnityProjects: Unity projects used to generate some of the test data.
-* TestCommon: a helper library used by the test projects.
+The solution is organised in three layers. At the base are the libraries that read Unity's binary
+formats. On top of those sit the feature libraries that turn that raw data into something useful
+(a database, a text dump, a reference graph). And at the top is the command-line tool that exposes
+all of that functionality to users.
+
+```mermaid
+flowchart TD
+    CLI["<b>UnityDataTool</b><br/>command-line tool<br/>(+ archive / serialized-file commands)"]
+
+    Analyzer["<b>Analyzer</b><br/>SQLite database"]
+    TextDumper["<b>TextDumper</b><br/>human-readable dump"]
+    ReferenceFinder["<b>ReferenceFinder</b><br/>reference chains"]
+
+    UnityFileSystem["<b>UnityFileSystem</b><br/>C# wrapper +<br/>UnityFileSystemApi (native)"]
+    UnityBinaryFormat["<b>UnityBinaryFormat</b><br/>C# parsers &amp; helpers<br/>for Archives / SerializedFiles"]
+    UnityDataModels["<b>UnityDataModels</b><br/>schemas for build reporting file formats"]
+
+    CLI --> Analyzer
+    CLI --> TextDumper
+    CLI --> ReferenceFinder
+    CLI --> UnityBinaryFormat
+    CLI --> UnityFileSystem
+
+    Analyzer --> UnityFileSystem
+    Analyzer --> UnityBinaryFormat
+    Analyzer --> UnityDataModels
+    TextDumper --> UnityFileSystem
+    TextDumper --> UnityBinaryFormat
+    UnityBinaryFormat --> UnityFileSystem
+
+    ReferenceFinder -. "reads the SQLite database" .-> Analyzer
+```
+
+**Command-line tool**
+* [UnityDataTool](Documentation/unitydatatool.md): the command-line tool. It wires the feature
+  libraries together and exposes them as commands (`analyze`, `dump`, `find-refs`, and more), so most
+  users only ever interact with this executable. It also directly contains the implementation of the
+  `archive` and `serialized-file` commands — critical features for working with the file formats,
+  built mostly on top of UnityBinaryFormat.
+
+**Feature libraries**
+* [Analyzer](Documentation/analyzer.md): extracts key information from Unity data files into a SQLite
+  database for detailed analysis. It also parses Addressables build reports.
+* [TextDumper](Documentation/textdumper.md): dumps SerializedFiles into a human-readable format
+  (similar to Unity's binary2text).
+* [ReferenceFinder](Documentation/referencefinder.md): finds reference chains from one object to
+  another by querying a database produced by the Analyzer (a data dependency rather than a code one).
+
+**Base libraries**
+* UnityFileSystem: a .NET class library, with source and binaries, that wraps the native
+  `UnityFileSystemApi` to mount Unity Archives and read SerializedFiles.
+* UnityBinaryFormat: C# parsers and helpers for reading data out of Unity Archives and SerializedFiles.
+* UnityDataModels: shared C# models for the reading JSON format files produced by the build (Addressables BuildLayout.json, Content Directory ContentLayout.json).
+
+## Purpose of UnityFileSystemApi
+
+UnityFileSystemApi is compiled from the Unity source code and exposes the core functionality to open and read the Unity Archive and Serialized File formats, exposed as a flexible, performant library. It exposes ability to navigates the TypeTrees inside a SerializedFile so objects can be read generically, without hardcoded type knowledge.
+
+It enables custom tools for binary2text-like output and efficient SQLite database generation.
+
+### Tests and test data
+
+The automated tests are not shown in the diagram above. Each library has its own test project, and the
+shared test data doubles as convenient sample content for ad hoc use of the tool.
+
+* TestCommon: a helper library whose `Data/` folder holds small reference files extracted from real
+  Unity builds (Player, AssetBundles, content directory etc). These back the automated tests and are also handy for trying out the tool by hand.
+* Analyzer.Tests, UnityDataTool.Tests, UnityFileSystem.Tests: the per-library test suites.
+* UnityProjects: two Unity projects (`Baseline` and `LeadingEdge`) used to regenerate some of the test
+  data as Unity evolves.
 
 ## Downloads
 
@@ -63,7 +120,7 @@ Refer to the [commit history](https://github.com/Unity-Technologies/UnityDataToo
 
 ## Getting UnityFileSystemApi
 
-UnityDataTool uses the native `UnityFileSystemApi` library to read Unity Archives and SerializedFiles. **Normally you don't need to do anything with this library.** The repository already includes a recent Windows, Mac, and Linux copy in the [`UnityFileSystem/`](https://github.com/Unity-Technologies/UnityDataTools/tree/main/UnityFileSystem) directory, and using that bundled copy is the recommended way to run the tool.
+UnityDataTool uses the pre-compiled `UnityFileSystemApi` library to read Unity Archives and SerializedFiles. **Normally you don't need to do anything with this library.** The repository already includes a recent Windows, Mac, and Linux copy in the [`UnityFileSystem/`](https://github.com/Unity-Technologies/UnityDataTools/tree/main/UnityFileSystem) directory, and using that bundled copy is the recommended way to run the tool.
 
 The library is backward compatible but not forward compatible: a given version can read content from the same or older Unity versions, but may be unable to read content produced by a newer Unity Editor than the library itself. The bundled copy is updated periodically as Unity evolves, so in practice it can read content from just about any Unity version.
 
@@ -83,10 +140,6 @@ The library is backward compatible but not forward compatible: a given version c
 On Windows, the executable is written to `UnityDataTool\bin\Release\net9.0`. Add this location to your system PATH for convenient access.
 
 See the [command-line tool documentation](./Documentation/unitydatatool.md) for usage instructions.
-
-## Purpose of UnityFileSystemApi
-
-UnityFileSystemApi exposes the core functionality of WebExtract and binary2text to open and read the Unity Archive and Serialized File formats, exposed as a flexible, performant library. It enables custom tools for binary2text-like output and efficient SQLite database generation.
 
 ## Origins
 

--- a/README.md
+++ b/README.md
@@ -101,7 +101,7 @@ flowchart TD
 
 ## Purpose of UnityFileSystemApi
 
-UnityFileSystemApi is compiled from the Unity source code and exposes the core functionality to open and read the Unity Archive and Serialized File formats, exposed as a flexible, performant library. It exposes ability to navigates the TypeTrees inside a SerializedFile so objects can be read generically, without hardcoded type knowledge.
+UnityFileSystemApi is compiled from the Unity source code and exposes the core functionality to open and read the Unity Archive and Serialized File formats as a flexible, performant library. It exposes the ability to navigate the TypeTrees inside a SerializedFile so objects can be read generically, without hardcoded type knowledge.
 
 It enables custom tools for binary2text-like output and efficient SQLite database generation.
 

--- a/README.md
+++ b/README.md
@@ -44,11 +44,13 @@ all of that functionality to users.
 
 ```mermaid
 flowchart TD
-    CLI["<b>UnityDataTool</b><br/>command-line tool<br/>(+ archive / serialized-file commands)"]
+    CLI["<b>UnityDataTool</b><br/>command-line tool"]
 
     Analyzer["<b>Analyzer</b><br/>SQLite database"]
     TextDumper["<b>TextDumper</b><br/>human-readable dump"]
     ReferenceFinder["<b>ReferenceFinder</b><br/>reference chains"]
+    Archive["<b>Archive</b><br/>inspect / extract archives"]
+    SerializedFile["<b>SerializedFile</b><br/>inspect SerializedFiles"]
 
     UnityFileSystem["<b>UnityFileSystem</b><br/>C# wrapper +<br/>UnityFileSystemApi (native)"]
     UnityBinaryFormat["<b>UnityBinaryFormat</b><br/>C# parsers &amp; helpers<br/>for Archives / SerializedFiles"]
@@ -57,14 +59,18 @@ flowchart TD
     CLI --> Analyzer
     CLI --> TextDumper
     CLI --> ReferenceFinder
-    CLI --> UnityBinaryFormat
-    CLI --> UnityFileSystem
+    CLI --> Archive
+    CLI --> SerializedFile
 
     Analyzer --> UnityFileSystem
     Analyzer --> UnityBinaryFormat
     Analyzer --> UnityDataModels
     TextDumper --> UnityFileSystem
     TextDumper --> UnityBinaryFormat
+    Archive --> UnityFileSystem
+    Archive --> UnityBinaryFormat
+    SerializedFile --> UnityFileSystem
+    SerializedFile --> UnityBinaryFormat
     UnityBinaryFormat --> UnityFileSystem
 
     ReferenceFinder -. "reads the SQLite database" .-> Analyzer
@@ -72,10 +78,8 @@ flowchart TD
 
 **Command-line tool**
 * [UnityDataTool](Documentation/unitydatatool.md): the command-line tool. It wires the feature
-  libraries together and exposes them as commands (`analyze`, `dump`, `find-refs`, and more), so most
-  users only ever interact with this executable. It also directly contains the implementation of the
-  `archive` and `serialized-file` commands — critical features for working with the file formats,
-  built mostly on top of UnityBinaryFormat.
+  libraries together and exposes them as commands (`analyze`, `dump`, `find-refs`, `archive`,
+  `serialized-file`, and more), so most users only ever interact with this executable.
 
 **Feature libraries**
 * [Analyzer](Documentation/analyzer.md): extracts key information from Unity data files into a SQLite
@@ -84,6 +88,10 @@ flowchart TD
   (similar to Unity's binary2text).
 * [ReferenceFinder](Documentation/referencefinder.md): finds reference chains from one object to
   another by querying a database produced by the Analyzer (a data dependency rather than a code one).
+* [Archive](Documentation/command-archive.md): inspects and extracts the contents of Unity Archives
+  (AssetBundles and web platform `.data` files) — the `archive` command.
+* [SerializedFile](Documentation/command-serialized-file.md): inspects the header, metadata, object
+  list, and external references of a SerializedFile — the `serialized-file` command.
 
 **Base libraries**
 * UnityFileSystem: a .NET class library, with source and binaries, that wraps the native

--- a/SerializedFile/README.md
+++ b/SerializedFile/README.md
@@ -1,0 +1,3 @@
+# SerializedFile
+
+See [Documentation/command-serialized-file.md](../Documentation/command-serialized-file.md)

--- a/SerializedFile/SerializedFile.csproj
+++ b/SerializedFile/SerializedFile.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Library</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+    <ApplicationIcon />
+    <StartupObject />
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
+  <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
+    <PlatformTarget>AnyCPU</PlatformTarget>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\UnityBinaryFormat\UnityBinaryFormat.csproj" />
+    <ProjectReference Include="..\UnityFileSystem\UnityFileSystem.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/SerializedFile/SerializedFileTool.cs
+++ b/SerializedFile/SerializedFileTool.cs
@@ -5,10 +5,16 @@ using System.Text.Json;
 using UnityDataTools.BinaryFormat;
 using UnityDataTools.FileSystem;
 
-namespace UnityDataTools.UnityDataTool;
+namespace UnityDataTools.SerializedFile;
 
-public static class SerializedFileCommands
+public static class SerializedFileTool
 {
+    public enum OutputFormat
+    {
+        Text,
+        Json
+    }
+
     public static int HandleExternalRefs(FileInfo filename, OutputFormat format)
     {
         // External references are read directly from the parsed metadata rather than via UnityFileSystemApi.

--- a/SerializedFile/SerializedFileTool.cs
+++ b/SerializedFile/SerializedFileTool.cs
@@ -15,7 +15,7 @@ public static class SerializedFileTool
         Json
     }
 
-    public static int HandleExternalRefs(FileInfo filename, OutputFormat format)
+    public static int ListExternalRefs(FileInfo filename, OutputFormat format)
     {
         // External references are read directly from the parsed metadata rather than via UnityFileSystemApi.
         //
@@ -50,10 +50,10 @@ public static class SerializedFileTool
         return 0;
     }
 
-    public static int HandleObjectList(FileInfo filename, OutputFormat format)
+    public static int ListObjects(FileInfo filename, OutputFormat format)
     {
         // The object list is read directly from the parsed metadata rather than via UnityFileSystemApi.
-        // (See comment in HandleExternalRefs() for the reasons for doing it that way)
+        // (See comment in ListExternalRefs() for the reasons for doing it that way)
         if (!ValidateSerializedFile(filename.FullName, out var fileInfo))
             return 1;
 
@@ -78,7 +78,7 @@ public static class SerializedFileTool
         return 0;
     }
 
-    public static int HandleHeader(FileInfo filename, OutputFormat format)
+    public static int PrintHeader(FileInfo filename, OutputFormat format)
     {
         if (!ValidateSerializedFile(filename.FullName, out var fileInfo))
             return 1;
@@ -91,7 +91,7 @@ public static class SerializedFileTool
         return 0;
     }
 
-    public static int HandleMetadata(FileInfo filename, OutputFormat format)
+    public static int PrintMetadata(FileInfo filename, OutputFormat format)
     {
         if (!ValidateSerializedFile(filename.FullName, out var fileInfo))
             return 1;

--- a/UnityDataTool.Tests/WebBundleSupportTests.cs
+++ b/UnityDataTool.Tests/WebBundleSupportTests.cs
@@ -5,6 +5,7 @@ using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
 using NUnit.Framework;
+using UnityDataTools.Archive;
 using UnityDataTools.FileSystem;
 
 namespace UnityDataTools.UnityDataTool.Tests;

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -225,7 +225,7 @@ public static class Program
             filterOpt,
         };
         extractArchiveCommand.SetHandler(
-            (FileInfo fi, DirectoryInfo o, string filter) => Task.FromResult(ArchiveTool.HandleExtract(fi, o, filter)),
+            (FileInfo fi, DirectoryInfo o, string filter) => Task.FromResult(ArchiveTool.ExtractContent(fi, o, filter)),
             pathArg, oOpt, filterOpt);
 
         var fOpt = new Option<ArchiveTool.OutputFormat>(aliases: new[] { "--format", "-f" }, description: "Output format", getDefaultValue: () => ArchiveTool.OutputFormat.Text);
@@ -236,7 +236,7 @@ public static class Program
             fOpt,
         };
         listArchiveCommand.SetHandler(
-            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.HandleList(fi, f)),
+            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.ListContent(fi, f)),
             pathArg, fOpt);
 
         var headerArchiveCommand = new Command("header", "Display the header of a Unity Archive file.")
@@ -245,7 +245,7 @@ public static class Program
             fOpt,
         };
         headerArchiveCommand.SetHandler(
-            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.HandleHeader(fi, f)),
+            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.PrintHeader(fi, f)),
             pathArg, fOpt);
 
         var blocksArchiveCommand = new Command("blocks", "Display the block list of a Unity Archive file.")
@@ -254,7 +254,7 @@ public static class Program
             fOpt,
         };
         blocksArchiveCommand.SetHandler(
-            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.HandleBlocks(fi, f)),
+            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.ListBlocks(fi, f)),
             pathArg, fOpt);
 
         var infoArchiveCommand = new Command("info", "Display a high-level summary of a Unity Archive file.")
@@ -263,7 +263,7 @@ public static class Program
             fOpt,
         };
         infoArchiveCommand.SetHandler(
-            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.HandleInfo(fi, f)),
+            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.PrintSummary(fi, f)),
             pathArg, fOpt);
 
         return new Command("archive", "Inspect or extract the contents of a Unity archive (AssetBundle or web platform .data file).")
@@ -287,7 +287,7 @@ public static class Program
             fOpt,
         };
         externalRefsCommand.SetHandler(
-            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.HandleExternalRefs(fi, f)),
+            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.ListExternalRefs(fi, f)),
             pathArg, fOpt);
 
         var objectListCommand = new Command("objectlist", "List all objects in a SerializedFile.")
@@ -296,7 +296,7 @@ public static class Program
             fOpt,
         };
         objectListCommand.SetHandler(
-            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.HandleObjectList(fi, f)),
+            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.ListObjects(fi, f)),
             pathArg, fOpt);
 
         var headerCommand = new Command("header", "Show SerializedFile header information.")
@@ -305,7 +305,7 @@ public static class Program
             fOpt,
         };
         headerCommand.SetHandler(
-            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.HandleHeader(fi, f)),
+            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.PrintHeader(fi, f)),
             pathArg, fOpt);
 
         var metadataCommand = new Command("metadata", "Show information from the metadata section of the SerializedFile (use `-f Json` for detailed information).")
@@ -314,7 +314,7 @@ public static class Program
             fOpt,
         };
         metadataCommand.SetHandler(
-            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.HandleMetadata(fi, f)),
+            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.PrintMetadata(fi, f)),
             pathArg, fOpt);
 
         var serializedFileCommand = new Command("serialized-file", "Inspect a SerializedFile (scene, assets, etc.).")

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -5,17 +5,13 @@ using System.IO;
 using System.Reflection;
 using System.Threading.Tasks;
 using UnityDataTools.Analyzer;
+using UnityDataTools.Archive;
 using UnityDataTools.FileSystem;
 using UnityDataTools.ReferenceFinder;
+using UnityDataTools.SerializedFile;
 using UnityDataTools.TextDumper;
 
 namespace UnityDataTools.UnityDataTool;
-
-public enum OutputFormat
-{
-    Text,
-    Json
-}
 
 public static class Program
 {
@@ -229,10 +225,10 @@ public static class Program
             filterOpt,
         };
         extractArchiveCommand.SetHandler(
-            (FileInfo fi, DirectoryInfo o, string filter) => Task.FromResult(Archive.HandleExtract(fi, o, filter)),
+            (FileInfo fi, DirectoryInfo o, string filter) => Task.FromResult(ArchiveTool.HandleExtract(fi, o, filter)),
             pathArg, oOpt, filterOpt);
 
-        var fOpt = new Option<OutputFormat>(aliases: new[] { "--format", "-f" }, description: "Output format", getDefaultValue: () => OutputFormat.Text);
+        var fOpt = new Option<ArchiveTool.OutputFormat>(aliases: new[] { "--format", "-f" }, description: "Output format", getDefaultValue: () => ArchiveTool.OutputFormat.Text);
 
         var listArchiveCommand = new Command("list", "List the contents of an AssetBundle or .data file.")
         {
@@ -240,7 +236,7 @@ public static class Program
             fOpt,
         };
         listArchiveCommand.SetHandler(
-            (FileInfo fi, OutputFormat f) => Task.FromResult(Archive.HandleList(fi, f)),
+            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.HandleList(fi, f)),
             pathArg, fOpt);
 
         var headerArchiveCommand = new Command("header", "Display the header of a Unity Archive file.")
@@ -249,7 +245,7 @@ public static class Program
             fOpt,
         };
         headerArchiveCommand.SetHandler(
-            (FileInfo fi, OutputFormat f) => Task.FromResult(Archive.HandleHeader(fi, f)),
+            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.HandleHeader(fi, f)),
             pathArg, fOpt);
 
         var blocksArchiveCommand = new Command("blocks", "Display the block list of a Unity Archive file.")
@@ -258,7 +254,7 @@ public static class Program
             fOpt,
         };
         blocksArchiveCommand.SetHandler(
-            (FileInfo fi, OutputFormat f) => Task.FromResult(Archive.HandleBlocks(fi, f)),
+            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.HandleBlocks(fi, f)),
             pathArg, fOpt);
 
         var infoArchiveCommand = new Command("info", "Display a high-level summary of a Unity Archive file.")
@@ -267,7 +263,7 @@ public static class Program
             fOpt,
         };
         infoArchiveCommand.SetHandler(
-            (FileInfo fi, OutputFormat f) => Task.FromResult(Archive.HandleInfo(fi, f)),
+            (FileInfo fi, ArchiveTool.OutputFormat f) => Task.FromResult(ArchiveTool.HandleInfo(fi, f)),
             pathArg, fOpt);
 
         return new Command("archive", "Inspect or extract the contents of a Unity archive (AssetBundle or web platform .data file).")
@@ -283,7 +279,7 @@ public static class Program
     static Command BuildSerializedFileCommand()
     {
         var pathArg = new Argument<FileInfo>("filename", "The path of the SerializedFile").ExistingOnly();
-        var fOpt = new Option<OutputFormat>(aliases: new[] { "--format", "-f" }, description: "Output format", getDefaultValue: () => OutputFormat.Text);
+        var fOpt = new Option<SerializedFileTool.OutputFormat>(aliases: new[] { "--format", "-f" }, description: "Output format", getDefaultValue: () => SerializedFileTool.OutputFormat.Text);
 
         var externalRefsCommand = new Command("externalrefs", "List external file references in a SerializedFile.")
         {
@@ -291,7 +287,7 @@ public static class Program
             fOpt,
         };
         externalRefsCommand.SetHandler(
-            (FileInfo fi, OutputFormat f) => Task.FromResult(SerializedFileCommands.HandleExternalRefs(fi, f)),
+            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.HandleExternalRefs(fi, f)),
             pathArg, fOpt);
 
         var objectListCommand = new Command("objectlist", "List all objects in a SerializedFile.")
@@ -300,7 +296,7 @@ public static class Program
             fOpt,
         };
         objectListCommand.SetHandler(
-            (FileInfo fi, OutputFormat f) => Task.FromResult(SerializedFileCommands.HandleObjectList(fi, f)),
+            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.HandleObjectList(fi, f)),
             pathArg, fOpt);
 
         var headerCommand = new Command("header", "Show SerializedFile header information.")
@@ -309,7 +305,7 @@ public static class Program
             fOpt,
         };
         headerCommand.SetHandler(
-            (FileInfo fi, OutputFormat f) => Task.FromResult(SerializedFileCommands.HandleHeader(fi, f)),
+            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.HandleHeader(fi, f)),
             pathArg, fOpt);
 
         var metadataCommand = new Command("metadata", "Show information from the metadata section of the SerializedFile (use `-f Json` for detailed information).")
@@ -318,7 +314,7 @@ public static class Program
             fOpt,
         };
         metadataCommand.SetHandler(
-            (FileInfo fi, OutputFormat f) => Task.FromResult(SerializedFileCommands.HandleMetadata(fi, f)),
+            (FileInfo fi, SerializedFileTool.OutputFormat f) => Task.FromResult(SerializedFileTool.HandleMetadata(fi, f)),
             pathArg, fOpt);
 
         var serializedFileCommand = new Command("serialized-file", "Inspect a SerializedFile (scene, assets, etc.).")

--- a/UnityDataTool/UnityDataTool.csproj
+++ b/UnityDataTool/UnityDataTool.csproj
@@ -20,14 +20,14 @@
 
   <ItemGroup>
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-    <PackageReference Include="System.IO.Packaging" Version="7.0.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <ProjectReference Include="..\ReferenceFinder\ReferenceFinder.csproj" />
-    <ProjectReference Include="..\TextDumper\TextDumper.csproj" />
     <ProjectReference Include="..\Analyzer\Analyzer.csproj" />
-    <ProjectReference Include="..\UnityBinaryFormat\UnityBinaryFormat.csproj" />
+    <ProjectReference Include="..\Archive\Archive.csproj" />
+    <ProjectReference Include="..\ReferenceFinder\ReferenceFinder.csproj" />
+    <ProjectReference Include="..\SerializedFile\SerializedFile.csproj" />
+    <ProjectReference Include="..\TextDumper\TextDumper.csproj" />
     <ProjectReference Include="..\UnityFileSystem\UnityFileSystem.csproj" />
   </ItemGroup>
 

--- a/UnityDataTools.sln
+++ b/UnityDataTools.sln
@@ -31,6 +31,10 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnityBinaryFormat", "UnityB
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "UnityDataModels", "UnityDataModels\UnityDataModels.csproj", "{E72FCD84-B200-4577-8440-788E33A4BEAF}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Archive", "Archive\Archive.csproj", "{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "SerializedFile", "SerializedFile\SerializedFile.csproj", "{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -173,6 +177,30 @@ Global
 		{E72FCD84-B200-4577-8440-788E33A4BEAF}.Release|x64.Build.0 = Release|Any CPU
 		{E72FCD84-B200-4577-8440-788E33A4BEAF}.Release|x86.ActiveCfg = Release|Any CPU
 		{E72FCD84-B200-4577-8440-788E33A4BEAF}.Release|x86.Build.0 = Release|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Debug|x64.Build.0 = Debug|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Debug|x86.Build.0 = Debug|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Release|Any CPU.Build.0 = Release|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Release|x64.ActiveCfg = Release|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Release|x64.Build.0 = Release|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Release|x86.ActiveCfg = Release|Any CPU
+		{53E144DE-48EB-4AA8-8BFD-7CF59EFCEB13}.Release|x86.Build.0 = Release|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Debug|x64.Build.0 = Debug|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Debug|x86.Build.0 = Debug|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Release|Any CPU.Build.0 = Release|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Release|x64.ActiveCfg = Release|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Release|x64.Build.0 = Release|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Release|x86.ActiveCfg = Release|Any CPU
+		{0DA72219-4B14-4BF5-B777-C88E5D87CBE2}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary

This is a documentation and refactoring change for the v2.0 release; there is no
associated issue.

The `README.md` "Repository content" section was reworked to actually explain the
solution's design, with a Mermaid diagram of how the projects layer (base libraries →
feature libraries → CLI) and prose describing each. While documenting this it became
clear that the `archive` and `serialized-file` commands were implemented directly inside
the `UnityDataTool` CLI assembly, whereas every other feature (`analyze`, `dump`,
`find-refs`) lives in its own class library. That inconsistency was awkward to document
and out of step with the rest of the repo, so those commands were extracted into their
own libraries to match the established one-library-per-feature pattern.

## Changes

### Documentation
- Rewrote the "Repository content" section of `README.md`: added a Mermaid dependency
  diagram, grouped the projects into command-line tool / feature libraries / base
  libraries, and added a short "Tests and test data" subsection.
- Updated the Component Hierarchy in `AGENTS.md` to match.

### Restructure
- Extracted the `archive` command into a new **Archive** library (`ArchiveTool` +
  `WebBundleHelper`) and the `serialized-file` command into a new **SerializedFile**
  library (`SerializedFileTool`). Both are peers of `TextDumper`, depending only on
  `UnityBinaryFormat` and `UnityFileSystem`.
- Each new library follows the existing conventions: an `<Name>Tool` class, a nested
  `OutputFormat` enum (mirroring `TextDumperTool.DumpFormat`), and a small folder
  `README.md` pointing at the corresponding `Documentation/command-*.md`.
- `Program.cs` is now purely CLI wiring; the `OutputFormat` enum and the
  `System.IO.Packaging` / `UnityBinaryFormat` references that only existed for those
  commands moved out of the CLI project accordingly.

### API naming
- Renamed the tool methods to be self-documenting about what they emit: `List*` for
  console listings of a collection, `Print*` for a single record/summary, `Extract*` for
  writing files (e.g. `HandleList` → `ListContent`, `HandleHeader` → `PrintHeader`,
  `HandleExtract` → `ExtractContent`). No behavior change.

## Testing

`dotnet test` — full suite green (725 passed, 10 skipped, 0 failed) and a clean Release
build with no warnings. The command tests exercise `archive` and `serialized-file`
end-to-end through `Program.Main`, so they cover the moved code and renamed API; no test
logic changed.
