### PR TITLE
[#85] Track dangling references in analyze

### DIFF
--- a/Analyzer/AnalyzerTool.cs
+++ b/Analyzer/AnalyzerTool.cs
@@ -5,8 +5,8 @@ using System.IO;
 using UnityDataTools.Analyzer.SQLite.Handlers;
 using UnityDataTools.Analyzer.SQLite.Parsers;
 using UnityDataTools.Analyzer.SQLite.Writers;
-using UnityDataTools.Models;
 using UnityDataTools.FileSystem;
+using UnityDataTools.Models;
 
 namespace UnityDataTools.Analyzer;
 
@@ -130,6 +130,13 @@ public class AnalyzerTool
 
         Console.WriteLine();
         Console.WriteLine($"Finalizing database. Successfully processed files: {countSuccess}, Failed files: {countFailures}, Files without TypeTrees: {countNoTypeTrees}, Ignored files: {countIgnored}");
+
+        // Record data that can only be determined once every file has been processed (e.g. which
+        // referenced objects were never resolved) before the database is finalized.
+        foreach (var parser in parsers)
+        {
+            parser.FinalizeDatabase();
+        }
 
         writer.End();
         foreach (var parser in parsers)

--- a/Analyzer/Resources/Init.sql
+++ b/Analyzer/Resources/Init.sql
@@ -81,12 +81,54 @@ CREATE TABLE IF NOT EXISTS refs
     property_type INTEGER
 );
 
+-- One row per referenced object that analyze assigned an id to but never wrote an objects row
+-- for (its serialized file was not part of the analyzed input). Written after all files are
+-- processed, once we can tell which assigned ids never became objects. Common causes: analyzing a
+-- partial set of AssetBundles, references into "unity default resources" (shipped without
+-- TypeTrees), or a ContentDirectory build analyzed without ContentLayout.json.
+-- Columns mirror the objects table so every object id resolves to exactly one of objects or
+-- dangling_refs:
+--   id - the analyzer object id (no row in objects has this id).
+--   object_id - the target's local file id (LFID / m_PathID) within its serialized file.
+--   serialized_file - references the serialized_files row of the (un-analyzed) file the target
+--        lives in. That row has archive NULL and no objects of its own.
+CREATE TABLE IF NOT EXISTS dangling_refs
+(
+    id INTEGER,
+    object_id INTEGER,
+    serialized_file INTEGER,
+    PRIMARY KEY (id)
+);
+
 -- Resolves the property_path and property_type ids in the refs table to their string values.
 CREATE VIEW refs_view AS
 SELECT r.object, r.referenced_object, pn.name AS property_path, pt.name AS property_type
 FROM refs r
 INNER JOIN property_names pn ON r.property_path = pn.id
 INNER JOIN property_types pt ON r.property_type = pt.id;
+
+-- Resolves dangling_refs to the source object(s) that reference each missing target, one row per
+-- (referencing object -> dangling target) reference. Because it joins refs, this view is empty
+-- when analyze is run with --skip-references even though the dangling_refs table may be populated.
+-- A dangling target only reached through preload_dependencies / game_object (not a refs row) is in
+-- the table but not here.
+CREATE VIEW dangling_refs_view AS
+SELECT
+    r.object AS source_id,
+    src_sf.name AS source_serialized_file,
+    src_o.object_id AS source_object_id,
+    pn.name AS property_path,
+    pt.name AS property_type,
+    d.id AS target_id,
+    tgt_sf.name AS target_serialized_file,
+    d.object_id AS target_object_id
+FROM dangling_refs d
+INNER JOIN refs r ON r.referenced_object = d.id
+INNER JOIN objects src_o ON r.object = src_o.id
+INNER JOIN serialized_files src_sf ON src_o.serialized_file = src_sf.id
+INNER JOIN serialized_files tgt_sf ON d.serialized_file = tgt_sf.id
+LEFT JOIN property_names pn ON r.property_path = pn.id
+LEFT JOIN property_types pt ON r.property_type = pt.id;
 
 CREATE VIEW object_view AS
 SELECT o.id, o.object_id, ab.name AS archive, sf.name AS serialized_file, t.name AS type, o.name, o.game_object, o.size,
@@ -157,8 +199,9 @@ INSERT INTO types (id, name) VALUES (-1, 'Scene');
 -- 1 = normalized refs table (issue #44); 2 = renamed assets/asset_dependencies tables to
 -- assetbundle_assets/preload_dependencies (issue #82); 3 = renamed asset_bundles table to archives
 -- and the asset_bundle column/alias to archive (issue #68); 4 = build_report_packed_asset_contents_view
--- type column changed from numeric id to type name (issue #55); databases produced before versioning report 0.
-PRAGMA user_version = 4;
+-- type column changed from numeric id to type name (issue #55); 5 = added dangling_refs table/view
+-- (issue #85); databases produced before versioning report 0.
+PRAGMA user_version = 5;
 
 PRAGMA synchronous = OFF;
 PRAGMA journal_mode = MEMORY;

--- a/Analyzer/Resources/Init.sql
+++ b/Analyzer/Resources/Init.sql
@@ -108,10 +108,8 @@ INNER JOIN property_names pn ON r.property_path = pn.id
 INNER JOIN property_types pt ON r.property_type = pt.id;
 
 -- Resolves dangling_refs to the source object(s) that reference each missing target, one row per
--- (referencing object -> dangling target) reference. Because it joins refs, this view is empty
--- when analyze is run with --skip-references even though the dangling_refs table may be populated.
--- A dangling target only reached through preload_dependencies / game_object (not a refs row) is in
--- the table but not here.
+-- (referencing object -> dangling target) reference. Not populated when analyze is run with
+-- --skip-references (neither refs nor dangling_refs are populated in that mode).
 CREATE VIEW dangling_refs_view AS
 SELECT
     r.object AS source_id,

--- a/Analyzer/SQLite/Commands/SerializedFile/AddDanglingRef.cs
+++ b/Analyzer/SQLite/Commands/SerializedFile/AddDanglingRef.cs
@@ -1,0 +1,29 @@
+using System.Collections.Generic;
+using Microsoft.Data.Sqlite;
+using UnityDataTools.Analyzer.SQLite.Commands;
+
+namespace UnityDataTools.Analyzer.SQLite.Commands.SerializedFile
+{
+    /* TABLE DEFINITION:
+    create table dangling_refs
+    (
+        id INTEGER,
+        object_id INTEGER,
+        serialized_file INTEGER,
+        PRIMARY KEY (id)
+    );
+    */
+    internal class AddDanglingRef : AbstractCommand
+    {
+        protected override string TableName => "dangling_refs";
+
+        protected override string DDLSource => null;
+
+        protected override Dictionary<string, SqliteType> Fields => new()
+        {
+            { "id", SqliteType.Integer },
+            { "object_id", SqliteType.Integer },
+            { "serialized_file", SqliteType.Integer }
+        };
+    }
+}

--- a/Analyzer/SQLite/Handlers/AssetBundleHandler.cs
+++ b/Analyzer/SQLite/Handlers/AssetBundleHandler.cs
@@ -68,6 +68,13 @@ public class AssetBundleHandler : ISQLiteHandler
         {
             if (!assetBundle.IsSceneAssetBundle)
             {
+                // Editor-only container entries (e.g. ShaderSubGraph, .preset) can appear in
+                // m_Container with a null PPtr (m_FileID 0 and m_PathID 0) because they have no
+                // runtime object. Skip them: resolving the null PPtr would allocate a phantom
+                // (file, 0) object id and record a bogus dangling reference to it.
+                if (asset.PPtr.FileId == 0 && asset.PPtr.PathId == 0)
+                    continue;
+
                 var fileId = ctx.LocalToDbFileId[asset.PPtr.FileId];
                 var objId = ctx.ObjectIdProvider.GetId((fileId, asset.PPtr.PathId));
                 m_InsertCommand.Transaction = ctx.Transaction;

--- a/Analyzer/SQLite/Handlers/ISQLiteHandler.cs
+++ b/Analyzer/SQLite/Handlers/ISQLiteHandler.cs
@@ -27,6 +27,12 @@ public interface ISQLiteFileParser : IDisposable
     void Init(SqliteConnection db);
     bool CanParse(string filename);
     void Parse(string filename);
+
+    // Called once after all files have been parsed, so a parser can write data that can only be
+    // determined from the complete set (e.g. dangling references). No-op for parsers that don't
+    // need it.
+    void FinalizeDatabase();
+
     public bool Verbose { get; set; }
     public bool SkipReferences { get; set; }
     public bool SkipCrc { get; set; }

--- a/Analyzer/SQLite/Parsers/AddressablesBuildLayoutParser.cs
+++ b/Analyzer/SQLite/Parsers/AddressablesBuildLayoutParser.cs
@@ -4,8 +4,8 @@ using Microsoft.Data.Sqlite;
 using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 using UnityDataTools.Analyzer.SQLite.Handlers;
-using UnityDataTools.Models;
 using UnityDataTools.Analyzer.SQLite.Writers;
+using UnityDataTools.Models;
 
 namespace UnityDataTools.Analyzer.SQLite.Parsers
 {
@@ -21,6 +21,12 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers
         {
             m_Writer.Dispose();
         }
+
+        public void FinalizeDatabase()
+        {
+            // Addressables build reports don't produce dangling object references.
+        }
+
         public void Init(SqliteConnection db)
         {
             m_Writer = new AddressablesBuildLayoutSQLWriter(db);

--- a/Analyzer/SQLite/Parsers/SerializedFileParser.cs
+++ b/Analyzer/SQLite/Parsers/SerializedFileParser.cs
@@ -35,6 +35,12 @@ namespace UnityDataTools.Analyzer.SQLite.Parsers
             m_Writer.Dispose();
         }
 
+        public void FinalizeDatabase()
+        {
+            // m_Writer is only Init'd once a file is actually parsed; nothing to finalize otherwise.
+            m_Writer.FinalizeDatabase();
+        }
+
         public void Init(SqliteConnection db)
         {
             m_Writer = new SerializedFileSQLiteWriter(db, SkipReferences, SkipCrc);

--- a/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
+++ b/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
@@ -279,17 +279,22 @@ public class SerializedFileSQLiteWriter : IDisposable
                     name = randomAccessReader["m_Name"].GetValue<string>();
                 }
 
+                // Resolve m_GameObject to its analyzer object id for the game_object column, but only
+                // when the PPtr is non-null. A null PPtr (m_FileID 0 and m_PathID 0) is expected for
+                // any object that is not a component; resolving it would allocate a phantom id for a
+                // (file, 0) object that never exists and then surface as a bogus dangling ref.
+                object gameObject = "";
                 if (randomAccessReader.HasChild("m_GameObject"))
                 {
                     var pptr = randomAccessReader["m_GameObject"];
-                    var fileId = m_LocalToDbFileId[pptr["m_FileID"].GetValue<int>()];
-                    var gameObjectID = m_ObjectIdProvider.GetId((fileId, pptr["m_PathID"].GetValue<long>()));
-                    m_AddObjectCommand.SetValue("game_object", gameObjectID);
+                    var gameObjectFileId = pptr["m_FileID"].GetValue<int>();
+                    var gameObjectPathId = pptr["m_PathID"].GetValue<long>();
+                    if (gameObjectFileId != 0 || gameObjectPathId != 0)
+                    {
+                        gameObject = m_ObjectIdProvider.GetId((m_LocalToDbFileId[gameObjectFileId], gameObjectPathId));
+                    }
                 }
-                else
-                {
-                    m_AddObjectCommand.SetValue("game_object", "");
-                }
+                m_AddObjectCommand.SetValue("game_object", gameObject);
 
                 // The walk both extracts references and accumulates the CRC, so it is needed
                 // unless both are disabled. When CRC is on but references are off, the walk

--- a/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
+++ b/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
@@ -367,7 +367,9 @@ public class SerializedFileSQLiteWriter : IDisposable
                 var (fileId, pathId) = entry.Key;
 
                 // Ensure the (un-analyzed) target file has a serialized_files row so the dangling
-                // ref can name it. archive is NULL: the file was referenced, not opened.
+                // ref can name it. We have to put null for archive - even if the target file is inside an AssetBundle
+                // or other archive file, because we simply don't have that information.  This is fundamental to
+                // how references work in Unity.
                 if (writtenFileIds.Add(fileId))
                 {
                     m_AddSerializedFileCommand.SetTransaction(transaction);

--- a/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
+++ b/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
@@ -74,6 +74,7 @@ public class SerializedFileSQLiteWriter : IDisposable
     private AddObject m_AddObjectCommand = new AddObject();
     private AddType m_AddTypeCommand = new AddType();
     private AddPreloadDependency m_InsertDepCommand = new AddPreloadDependency();
+    private AddDanglingRef m_AddDanglingRefCommand = new AddDanglingRef();
 
     private bool m_Initialized;
     private SqliteConnection m_Database;
@@ -112,6 +113,7 @@ public class SerializedFileSQLiteWriter : IDisposable
         m_AddObjectCommand.CreateCommand(m_Database);
         m_AddTypeCommand.CreateCommand(m_Database);
         m_InsertDepCommand.CreateCommand(m_Database);
+        m_AddDanglingRefCommand.CreateCommand(m_Database);
 
         m_LastId = m_Database.CreateCommand();
         m_LastId.CommandText = "SELECT last_insert_rowid()";
@@ -328,6 +330,76 @@ public class SerializedFileSQLiteWriter : IDisposable
         }
     }
 
+    // Records every referenced object that was assigned an id but never written to the objects
+    // table (its serialized file was not part of the analyzed input). Must run after all files are
+    // processed, since an id is only known to be dangling once nothing has claimed it as an object.
+    // The set of written objects/files is read back from the database so this is robust to every
+    // object write site (regular objects, synthetic Scene objects, etc.) without instrumenting them.
+    public void FinalizeDatabase()
+    {
+        // Dangling refs are part of reference tracking, so honor --skip-references (the view that
+        // makes them useful joins the refs table, which is empty in that mode anyway).
+        if (!m_Initialized || m_SkipReferences)
+            return;
+
+        var writtenObjectIds = ReadIntSet("SELECT id FROM objects");
+        var writtenFileIds = ReadIntSet("SELECT id FROM serialized_files");
+
+        // Invert the file-name provider so a dangling target's file id maps back to its name.
+        var fileIdToName = new Dictionary<int, string>();
+        foreach (var entry in m_SerializedFileIdProvider.Entries)
+            fileIdToName[entry.Value] = entry.Key;
+
+        using var transaction = m_Database.BeginTransaction();
+        try
+        {
+            foreach (var entry in m_ObjectIdProvider.Entries)
+            {
+                var objectId = entry.Value;
+                if (writtenObjectIds.Contains(objectId))
+                    continue;
+
+                var (fileId, pathId) = entry.Key;
+
+                // Ensure the (un-analyzed) target file has a serialized_files row so the dangling
+                // ref can name it. archive is NULL: the file was referenced, not opened.
+                if (writtenFileIds.Add(fileId))
+                {
+                    m_AddSerializedFileCommand.SetTransaction(transaction);
+                    m_AddSerializedFileCommand.SetValue("id", fileId);
+                    m_AddSerializedFileCommand.SetValue("archive", null);
+                    m_AddSerializedFileCommand.SetValue("name",
+                        fileIdToName.TryGetValue(fileId, out var name) ? name : "");
+                    m_AddSerializedFileCommand.ExecuteNonQuery();
+                }
+
+                m_AddDanglingRefCommand.SetTransaction(transaction);
+                m_AddDanglingRefCommand.SetValue("id", objectId);
+                m_AddDanglingRefCommand.SetValue("object_id", pathId);
+                m_AddDanglingRefCommand.SetValue("serialized_file", fileId);
+                m_AddDanglingRefCommand.ExecuteNonQuery();
+            }
+
+            transaction.Commit();
+        }
+        catch (Exception)
+        {
+            transaction.Rollback();
+            throw;
+        }
+    }
+
+    private HashSet<int> ReadIntSet(string sql)
+    {
+        var result = new HashSet<int>();
+        using var command = m_Database.CreateCommand();
+        command.CommandText = sql;
+        using var reader = command.ExecuteReader();
+        while (reader.Read())
+            result.Add(reader.GetInt32(0));
+        return result;
+    }
+
     // Callback from PPtrAndCrcProcessor for each reference discovered in the SerializedFile
     private int AddReference(long objectId, int fileId, long pathId, string propertyPath, string propertyType)
     {
@@ -395,6 +467,7 @@ public class SerializedFileSQLiteWriter : IDisposable
         m_AddObjectCommand.Dispose();
         m_AddTypeCommand.Dispose();
         m_InsertDepCommand.Dispose();
+        m_AddDanglingRefCommand.Dispose();
 
         m_LastId.Dispose();
     }

--- a/Analyzer/Util/IdProvider.cs
+++ b/Analyzer/Util/IdProvider.cs
@@ -11,6 +11,10 @@ public class IdProvider<Key>
 {
     private Dictionary<Key, int> m_Ids = new();
 
+    // Exposes the key->id assignments so callers can iterate or invert the mapping (used at
+    // finalize to map a dangling object id back to its (fileId, pathId) or file name).
+    public IReadOnlyDictionary<Key, int> Entries => m_Ids;
+
     public int GetId(Key key)
     {
         if (m_Ids.TryGetValue(key, out var id))

--- a/Documentation/analyzer.md
+++ b/Documentation/analyzer.md
@@ -98,7 +98,8 @@ What the `object` is depends on the build:
   `sharedassetsN.assets`) plus one in `globalgamemanagers.assets` for the always-loaded set.
 
 The `dependency` side can reference an object that analyze never recorded, leaving a "dangling" id
-with no matching `objects` row. The most common case is objects in `unity default resources`, the
+with no matching `objects` row (such ids are catalogued in the `dangling_refs` table). The most
+common case is objects in `unity default resources`, the
 built-in resource file that ships with the Unity Editor without TypeTrees and so cannot be analyzed
 without a specially built copy. (`Resources/unity_builtin_extra` is built alongside your content and
 can be analyzed, but produces the same dangling references when it is not part of the analyzed set.)
@@ -250,6 +251,37 @@ SELECT * FROM refs_view WHERE property_type = 'MonoScript';
 ```
 
 These tables are not populated when analyze is run with `--skip-references`.
+
+## dangling_refs / dangling_refs_view
+
+When a reference points to an object whose serialized file was not part of the analyzed input,
+analyze still assigns that target an object id but never writes an `objects` row for it. `dangling_refs`
+records those targets so the reference information is preserved and every object id is accounted for
+(each id resolves to exactly one of `objects` or `dangling_refs`, never both). Common causes:
+
+* Analyzing a single AssetBundle or a partial subset of a bundle group, so cross-bundle references
+  point at bundles that were not analyzed.
+* A Player build referencing `unity default resources` (and `Resources/unity_builtin_extra` when it
+  is not part of the analyzed set) - built-in files that ship without TypeTrees and are not analyzed.
+* A ContentDirectory build analyzed without its `ContentLayout.json`, so references cannot be resolved.
+
+The columns mirror the `objects` table: `id` (the assigned object id, absent from `objects`),
+`object_id` (the target's local file id / LFID) and `serialized_file`. The target file is recorded in
+`serialized_files` (with `archive` NULL and no objects of its own) so its name is available; the
+lowercased file name is all that is known about it - there is no type, size, or other detail.
+
+`dangling_refs_view` joins each dangling target back to the object(s) that reference it, one row per
+reference, with columns `source_id`, `source_serialized_file`, `source_object_id`, `property_path`,
+`property_type`, `target_id`, `target_serialized_file`, `target_object_id`.
+
+```sql
+-- what does object 42 fail to resolve, and where should those objects have come from?
+SELECT * FROM dangling_refs_view WHERE source_id = 42;
+```
+
+Because the view joins `refs`, it is empty when analyze is run with `--skip-references`; in that mode
+the `dangling_refs` table is not populated either. A dangling target reached only through
+`preload_dependencies` or a `game_object` link (not a `refs` row) appears in the table but not the view.
 
 ## BuildReport
 

--- a/Documentation/analyzer.md
+++ b/Documentation/analyzer.md
@@ -279,9 +279,8 @@ reference, with columns `source_id`, `source_serialized_file`, `source_object_id
 SELECT * FROM dangling_refs_view WHERE source_id = 42;
 ```
 
-Because the view joins `refs`, it is empty when analyze is run with `--skip-references`; in that mode
-the `dangling_refs` table is not populated either. A dangling target reached only through
-`preload_dependencies` or a `game_object` link (not a `refs` row) appears in the table but not the view.
+Because the view joins `refs`, it is not populated when analyze is run with `--skip-references`
+(in that mode neither `refs` nor `dangling_refs` are populated).
 
 ## BuildReport
 

--- a/UnityDataTool.Tests/AnalyzeDanglingRefsTests.cs
+++ b/UnityDataTool.Tests/AnalyzeDanglingRefsTests.cs
@@ -1,0 +1,94 @@
+using System.IO;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
+using NUnit.Framework;
+
+namespace UnityDataTools.UnityDataTool.Tests;
+
+#pragma warning disable NUnit2005, NUnit2006
+
+// Tests the dangling_refs table/view (issue #85): references to objects whose serialized file was
+// not part of the analyzed input get recorded instead of leaving unexplained gaps in the object id
+// space. Uses the LeadingEdge AssetBundles fixture, where assetbundleroot.manifest declares
+// dependencies on three other bundles, so analyzing assetbundleroot alone leaves cross-bundle
+// references dangling; analyzing the whole set resolves them.
+public class AnalyzeDanglingRefsTests
+{
+    private string m_TestOutputFolder;
+    private string m_AssetBundlesFolder;
+
+    [OneTimeSetUp]
+    public void OneTimeSetup()
+    {
+        m_TestOutputFolder = Path.Combine(TestContext.CurrentContext.TestDirectory, "dangling_refs_test_folder");
+        m_AssetBundlesFolder = Path.Combine(TestContext.CurrentContext.TestDirectory,
+            "Data", "LeadingEdgeBuilds", "AssetBundles");
+        Directory.CreateDirectory(m_TestOutputFolder);
+        Directory.SetCurrentDirectory(m_TestOutputFolder);
+    }
+
+    [TearDown]
+    public void Teardown()
+    {
+        SqliteConnection.ClearAllPools();
+        new DirectoryInfo(m_TestOutputFolder).EnumerateFiles().ToList().ForEach(f => f.Delete());
+    }
+
+    // Every referenced object must resolve to exactly one of objects/dangling_refs: nothing left
+    // unaccounted for, and no id in both tables. This is the core guarantee of the feature.
+    private static void AssertReferencesFullyAccounted(SqliteConnection db)
+    {
+        SQLTestHelper.AssertQueryInt(db,
+            @"SELECT COUNT(*) FROM refs r
+              LEFT JOIN objects o       ON o.id = r.referenced_object
+              LEFT JOIN dangling_refs d ON d.id = r.referenced_object
+              WHERE o.id IS NULL AND d.id IS NULL",
+            0, "every refs.referenced_object should resolve to an objects or dangling_refs row");
+        SQLTestHelper.AssertQueryInt(db,
+            "SELECT COUNT(*) FROM dangling_refs d INNER JOIN objects o ON o.id = d.id",
+            0, "an id must not be in both objects and dangling_refs");
+    }
+
+    [Test]
+    public async Task Analyze_PartialAssetBundleSet_RecordsCrossBundleDanglingRefs()
+    {
+        // Analyze only assetbundleroot; its references into the dependency bundles dangle.
+        var bundlePath = Path.Combine(m_AssetBundlesFolder, "assetbundleroot");
+        var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
+
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", bundlePath, "-o", databasePath }));
+        using var db = SQLTestHelper.OpenDatabase(databasePath);
+
+        Assert.Greater(SQLTestHelper.QueryInt(db, "SELECT COUNT(*) FROM dangling_refs"), 0,
+            "analyzing a single bundle should leave cross-bundle references dangling");
+        Assert.Greater(SQLTestHelper.QueryInt(db, "SELECT COUNT(*) FROM dangling_refs_view"), 0,
+            "the dangling references should be visible in dangling_refs_view");
+
+        // The dangling targets live in files that were referenced but not analyzed, so those files
+        // get a serialized_files row with no objects of their own.
+        SQLTestHelper.AssertQueryInt(db,
+            @"SELECT COUNT(*) FROM dangling_refs d
+              WHERE d.serialized_file IN (SELECT serialized_file FROM objects)
+                AND (SELECT COUNT(*) FROM refs r WHERE r.referenced_object = d.id) > 0",
+            0, "referenced dangling targets should be in files that were not analyzed");
+
+        AssertReferencesFullyAccounted(db);
+    }
+
+    [Test]
+    public async Task Analyze_FullAssetBundleSet_ResolvesCrossBundleReferences()
+    {
+        // Analyzing the whole set brings the dependency bundles in, so no reference dangles into an
+        // un-analyzed file: dangling_refs_view (which joins refs) is empty.
+        var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
+
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", m_AssetBundlesFolder, "-o", databasePath }));
+        using var db = SQLTestHelper.OpenDatabase(databasePath);
+
+        SQLTestHelper.AssertQueryInt(db, "SELECT COUNT(*) FROM dangling_refs_view", 0,
+            "analyzing the full set should resolve every cross-bundle reference");
+
+        AssertReferencesFullyAccounted(db);
+    }
+}

--- a/UnityDataTool.Tests/AnalyzeDanglingRefsTests.cs
+++ b/UnityDataTool.Tests/AnalyzeDanglingRefsTests.cs
@@ -48,6 +48,11 @@ public class AnalyzeDanglingRefsTests
         SQLTestHelper.AssertQueryInt(db,
             "SELECT COUNT(*) FROM dangling_refs d INNER JOIN objects o ON o.id = d.id",
             0, "an id must not be in both objects and dangling_refs");
+        // LFID 0 is never a real object; a dangling row with object_id 0 means a null PPtr (e.g. a
+        // null m_GameObject) was mistakenly resolved to a phantom (file, 0) id.
+        SQLTestHelper.AssertQueryInt(db,
+            "SELECT COUNT(*) FROM dangling_refs WHERE object_id = 0",
+            0, "dangling_refs should not contain phantom object_id 0 entries");
     }
 
     [Test]

--- a/UnityDataTool.Tests/ExpectedDataGenerator.cs
+++ b/UnityDataTool.Tests/ExpectedDataGenerator.cs
@@ -44,7 +44,7 @@ public static class ExpectedDataGenerator
                     (SELECT COUNT(*) FROM monoscripts),
                     (SELECT COUNT(*) FROM objects),
                     (SELECT COUNT(*) FROM refs),
-                    (SELECT COUNT(*) FROM serialized_files),
+                    (SELECT COUNT(*) FROM serialized_files WHERE id IN (SELECT serialized_file FROM objects)),
                     (SELECT COUNT(*) FROM shader_subprograms),
                     (SELECT COUNT(*) FROM shaders),
                     (SELECT COUNT(*) FROM shader_keywords),

--- a/UnityDataTool.Tests/UnityDataToolAssetBundleTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolAssetBundleTests.cs
@@ -334,7 +334,9 @@ public class UnityDataToolAssetBundleTests : AssetBundleTestFixture
                     (SELECT COUNT(*) FROM meshes),
                     (SELECT COUNT(*) FROM objects),
                     (SELECT COUNT(*) FROM refs),
-                    (SELECT COUNT(*) FROM serialized_files),
+                    -- Count only analyzed files; serialized_files now also holds referenced-but-not-analyzed
+                    -- files that are dangling-ref targets (issue #85), which are not part of this count.
+                    (SELECT COUNT(*) FROM serialized_files WHERE id IN (SELECT serialized_file FROM objects)),
                     (SELECT COUNT(*) FROM shader_subprograms),
                     (SELECT COUNT(*) FROM shaders),
                     (SELECT COUNT(*) FROM shader_keywords),

--- a/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
@@ -1,8 +1,8 @@
 using System;
-using Microsoft.Data.Sqlite;
 using System.IO;
 using System.Text.RegularExpressions;
 using System.Threading.Tasks;
+using Microsoft.Data.Sqlite;
 using NUnit.Framework;
 using UnityDataTools.TestCommon;
 
@@ -54,7 +54,8 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
                 (SELECT COUNT(*) FROM assetbundle_assets),
                 (SELECT COUNT(*) FROM objects),
                 (SELECT COUNT(*) FROM refs),
-                (SELECT COUNT(*) FROM serialized_files)";
+                -- Analyzed files only; serialized_files also holds dangling-ref target files (issue #85).
+                (SELECT COUNT(*) FROM serialized_files WHERE id IN (SELECT serialized_file FROM objects))";
 
         using var reader = cmd.ExecuteReader();
 
@@ -93,6 +94,44 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
         SQLTestHelper.AssertQueryInt(db,
             "SELECT COUNT(*) FROM preload_dependencies d LEFT JOIN objects o ON o.id = d.object WHERE o.id IS NULL",
             0, "every preload_dependencies.object should resolve to an objects row");
+    }
+
+    [Test]
+    public async Task Analyze_PlayerData_RecordsDanglingRefsToDefaultResources()
+    {
+        // Issue #85: a player build references objects in "unity default resources" (shipped without
+        // TypeTrees, never analyzed). Those references must be recorded in dangling_refs instead of
+        // leaving unexplained gaps in the object id space.
+        var analyzePath = Path.Combine(TestContext.CurrentContext.TestDirectory, "Data", "PlayerWithTypeTrees");
+        var databasePath = SQLTestHelper.GetDatabasePath(m_TestOutputFolder);
+
+        Assert.AreEqual(0, await Program.Main(new string[] { "analyze", analyzePath, "-o", databasePath }));
+        using var db = SQLTestHelper.OpenDatabase(databasePath);
+
+        Assert.Greater(SQLTestHelper.QueryInt(db, "SELECT COUNT(*) FROM dangling_refs"), 0,
+            "the player build should have dangling references (e.g. into unity default resources)");
+
+        // "unity default resources" is recorded as a serialized_files row and is a dangling target.
+        Assert.Greater(SQLTestHelper.QueryInt(db,
+            @"SELECT COUNT(*) FROM dangling_refs d
+              INNER JOIN serialized_files sf ON sf.id = d.serialized_file
+              WHERE sf.name = 'unity default resources'"),
+            0, "expected dangling references into 'unity default resources'");
+
+        // The dangling references are visible in the view, with real analyzed source files.
+        Assert.Greater(SQLTestHelper.QueryInt(db, "SELECT COUNT(*) FROM dangling_refs_view"), 0,
+            "dangling references should be visible in dangling_refs_view");
+
+        // Every referenced object resolves to exactly one of objects/dangling_refs.
+        SQLTestHelper.AssertQueryInt(db,
+            @"SELECT COUNT(*) FROM refs r
+              LEFT JOIN objects o       ON o.id = r.referenced_object
+              LEFT JOIN dangling_refs d ON d.id = r.referenced_object
+              WHERE o.id IS NULL AND d.id IS NULL",
+            0, "every refs.referenced_object should resolve to an objects or dangling_refs row");
+        SQLTestHelper.AssertQueryInt(db,
+            "SELECT COUNT(*) FROM dangling_refs d INNER JOIN objects o ON o.id = d.id",
+            0, "an id must not be in both objects and dangling_refs");
     }
 
     [Test]

--- a/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
+++ b/UnityDataTool.Tests/UnityDataToolPlayerDataTests.cs
@@ -132,6 +132,11 @@ public class UnityDataToolPlayerDataTests : PlayerDataTestFixture
         SQLTestHelper.AssertQueryInt(db,
             "SELECT COUNT(*) FROM dangling_refs d INNER JOIN objects o ON o.id = d.id",
             0, "an id must not be in both objects and dangling_refs");
+        // LFID 0 is never a real object; a dangling row with object_id 0 means a null PPtr (e.g. a
+        // null m_GameObject) was mistakenly resolved to a phantom (file, 0) id.
+        SQLTestHelper.AssertQueryInt(db,
+            "SELECT COUNT(*) FROM dangling_refs WHERE object_id = 0",
+            0, "dangling_refs should not contain phantom object_id 0 entries");
     }
 
     [Test]


### PR DESCRIPTION
## Summary

Fixes #85.

When `analyze` walks a SerializedFile and finds a reference (PPtr) to an object whose serialized file was **not** part of the analyzed input, it still assigns that target an object id but never writes an `objects` row for it. Until now the only trace of these targets was an unexplained gap in the otherwise-dense object id sequence, and the information the reference actually carried — the target's serialized file name and local file id (LFID) — was discarded.

This adds a `dangling_refs` table and `dangling_refs_view` that record those unresolved targets, so every object id now resolves to exactly one of `objects` or `dangling_refs`, and the referenced file/LFID are preserved. Common cases: analyzing a single AssetBundle or a partial bundle group (cross-bundle references dangle), a Player build referencing `unity default resources` (shipped without TypeTrees, never analyzed), and ContentDirectory builds analyzed without `ContentLayout.json`.

Two pre-existing bugs in how null PPtrs were handled surfaced once these gaps became visible, and are fixed here too (see Changes).

## Changes

### dangling_refs table + view
- **`dangling_refs`** — one row per referenced object that got an id but no `objects` row. Columns mirror `objects` (`id`, `object_id` = target LFID, `serialized_file`) so the two tables partition the id space.
- **`dangling_refs_view`** — resolves each dangling target back to the object(s) that reference it, one row per reference (`source_id`, `source_serialized_file`, `source_object_id`, `property_path`, `property_type`, `target_id`, `target_serialized_file`, `target_object_id`).
- Referenced-but-not-analyzed target files are recorded in `serialized_files` (with `archive` NULL and no objects of their own) so their name is available.
- Detection runs after all files are processed, via a new `ISQLiteFileParser.FinalizeDatabase()` hook called from `AnalyzerTool` before the database is finalized: the writer reads back the written object/file ids and records any assigned id that never became an object. It honors `--skip-references` (in that mode neither `refs` nor `dangling_refs` are populated).
- Schema `user_version` bumped 4 → 5.

### Null-PPtr fixes (bugs the feature exposed)
- **Null `m_GameObject`**: the writer resolved a component's `m_GameObject` even when it was a null PPtr (`m_FileID 0`, `m_PathID 0` — expected for any non-component object), allocating a phantom `(file, 0)` id. Now only resolved when non-null; otherwise the `game_object` column is left empty, as the no-`m_GameObject` branch already did.
- **Null `m_Container` entries**: editor-only assets (ShaderSubGraph, `.preset`) can appear in an AssetBundle's `m_Container` with a null PPtr because they have no runtime object. `AssetBundleHandler` resolved these to a phantom id and wrote an `assetbundle_assets` row pointing at it. These entries are now skipped; `assetbundle_asset_view` already excluded them via its INNER JOIN, so only rows that pointed at a non-existent object are dropped.

### Docs
- `Documentation/analyzer.md` — new `dangling_refs` / `dangling_refs_view` sections and a cross-link from the existing "dangling" note under `preload_dependencies`.

## Testing

- `dotnet test` — full suite green (UnityFileSystem.Tests 425, Analyzer.Tests 62, UnityDataTool.Tests 241).
- New coverage in `AnalyzeDanglingRefsTests` (partial vs. full LeadingEdge AssetBundle analyze) and `UnityDataToolPlayerDataTests` (Player build → `unity default resources`): assert the id-space accounting invariant (every `refs.referenced_object` resolves to `objects` or `dangling_refs`, and the two never overlap) and that no phantom `object_id = 0` rows are recorded.
- Existing `serialized_files` count assertions now count analyzed files only (equal to the previous golden values, so no `ExpectedData` regeneration was needed).
- Manual: ran `analyze` on a large Addressables customer build. Before the null-PPtr fixes it produced two false `object_id = 0` dangling refs into already-analyzed CABs; after, `dangling_refs` contains only the expected `unity default resources` targets, with the accounting invariants intact.
