### PR TITLE
Match SerializedFile names case-sensitively

### DIFF
--- a/Analyzer/SQLite/Handlers/AssetBundleHandler.cs
+++ b/Analyzer/SQLite/Handlers/AssetBundleHandler.cs
@@ -98,7 +98,7 @@ public class AssetBundleHandler : ISQLiteHandler
                 // Scriptable Build Pipeline / Addressables: key the scene on its SerializedFile
                 // (from m_SceneHashes) and create the synthetic Scene object here, since the writer
                 // cannot recognise a "CAB-<hash>" scene file by name.
-                var sceneFileId = ctx.SerializedFileIdProvider.GetId(sceneFile.ToLowerInvariant());
+                var sceneFileId = ctx.SerializedFileIdProvider.GetId(sceneFile);
                 var objId = ctx.ObjectIdProvider.GetId((sceneFileId, 0));
 
                 // The synthetic Scene object is inserted once (objects.id is a primary key), but the

--- a/Analyzer/SQLite/Writers/ContentLayoutSQLWriter.cs
+++ b/Analyzer/SQLite/Writers/ContentLayoutSQLWriter.cs
@@ -203,11 +203,11 @@ namespace UnityDataTools.Analyzer.SQLite.Writers
 
                 var resolved = (file.SerializedFileDependencies ?? [])
                     .Select(i => hashByIndex.TryGetValue(i, out var hash) && !string.IsNullOrEmpty(hash)
-                        ? (hash + ".cf").ToLowerInvariant()
+                        ? hash + ".cf"
                         : null)
                     .ToArray();
 
-                m_ContentFileDependencies.Add((file.ContentHash + ".cf").ToLowerInvariant(), resolved);
+                m_ContentFileDependencies.Add(file.ContentHash + ".cf", resolved);
             }
         }
 
@@ -246,7 +246,7 @@ namespace UnityDataTools.Analyzer.SQLite.Writers
             {
                 foreach (var file in m_ImportedFiles)
                 {
-                    var fileName = (file.ContentHash + ".cf").ToLowerInvariant();
+                    var fileName = file.ContentHash + ".cf";
                     var id = m_SerializedFileIdProvider.GetId(fileName);
 
                     update.Parameters["@id"].Value = id;

--- a/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
+++ b/Analyzer/SQLite/Writers/SerializedFileSQLiteWriter.cs
@@ -185,7 +185,7 @@ public class SerializedFileSQLiteWriter : IDisposable
         using var sf = UnityFileSystem.OpenSerializedFile(fullPath);
         using var reader = new UnityFileReader(fullPath, 64 * 1024 * 1024);
         using var pptrReader = new PPtrAndCrcProcessor(sf, reader, containingFolder, m_SkipCrc, AddReference);
-        int serializedFileId = m_SerializedFileIdProvider.GetId(Path.GetFileName(fullPath).ToLowerInvariant());
+        int serializedFileId = m_SerializedFileIdProvider.GetId(Path.GetFileName(fullPath));
         int sceneId = -1;
 
         // Two SerializedFiles with the same name map to the same id (the provider deduplicates by
@@ -244,7 +244,7 @@ public class SerializedFileSQLiteWriter : IDisposable
             // path -> file mapping from the AssetBundle object's m_SceneHashes.
             var fileName = Path.GetFileName(fullPath);
             var sceneFileName = fileName.Substring(0, fileName.Length - ".sharedAssets".Length);
-            var sceneFileId = m_SerializedFileIdProvider.GetId(sceneFileName.ToLowerInvariant());
+            var sceneFileId = m_SerializedFileIdProvider.GetId(sceneFileName);
             sceneId = m_ObjectIdProvider.GetId((sceneFileId, 0));
         }
 
@@ -272,12 +272,13 @@ public class SerializedFileSQLiteWriter : IDisposable
 
             // Local file id 0 is always this file itself; ids 1..N follow the order of the
             // external reference table. Resolve each external reference to its global file id
-            // by (lowercased) file name. For ContentDirectory files the external table holds
-            // symbolic placeholders, so when an imported ContentLayout covers this file the
-            // actual target comes from its dependency list, matched by position; built-in
-            // dependencies (null entries) keep the external table path.
+            // by file name (matched case-sensitively, as it appears on disk / in the archive).
+            // For ContentDirectory files the external table holds symbolic placeholders, so when
+            // an imported ContentLayout covers this file the actual target comes from its
+            // dependency list, matched by position; built-in dependencies (null entries) keep the
+            // external table path.
             var resolvedDependencies = m_ContentFileDependencies.GetDependencies(
-                Path.GetFileName(fullPath).ToLowerInvariant());
+                Path.GetFileName(fullPath));
 
             if (resolvedDependencies != null && resolvedDependencies.Length != sf.ExternalReferences.Count)
             {
@@ -292,7 +293,7 @@ public class SerializedFileSQLiteWriter : IDisposable
             foreach (var extRef in sf.ExternalReferences)
             {
                 var name = resolvedDependencies?[localId - 1]
-                    ?? extRef.Path.Substring(extRef.Path.LastIndexOf('/') + 1).ToLowerInvariant();
+                    ?? extRef.Path.Substring(extRef.Path.LastIndexOf('/') + 1);
                 m_LocalToDbFileId.Add(localId++, m_SerializedFileIdProvider.GetId(name));
             }
 

--- a/Analyzer/Util/ContentFileDependencyMap.cs
+++ b/Analyzer/Util/ContentFileDependencyMap.cs
@@ -6,8 +6,8 @@ namespace UnityDataTools.Analyzer.Util;
 // In ContentDirectory builds the external reference table inside a SerializedFile holds symbolic
 // .cfid placeholders instead of real filenames; the actual target of a reference is determined
 // positionally through the layout's dependency list (see Documentation/contentdirectory-format.md).
-// This map holds, for each content file (keyed by its lowercased "<contenthash>.cf" filename),
-// the resolved dependency filenames in external-reference-table order. An entry is null where the
+// This map holds, for each content file (keyed by its "<contenthash>.cf" filename), the resolved
+// dependency filenames in external-reference-table order. An entry is null where the
 // dependency is a built-in file (which has no content hash); such references fall back to the
 // path from the external reference table.
 public class ContentFileDependencyMap
@@ -19,8 +19,8 @@ public class ContentFileDependencyMap
         m_Dependencies[fileName] = resolvedDependencies;
     }
 
-    // Returns the resolved dependency filenames for the given (lowercased) filename, or null if
-    // the file is not covered by an imported ContentLayout.
+    // Returns the resolved dependency filenames for the given filename, or null if the file is
+    // not covered by an imported ContentLayout.
     public string[] GetDependencies(string fileName)
     {
         return m_Dependencies.TryGetValue(fileName, out var dependencies) ? dependencies : null;


### PR DESCRIPTION
## Summary

Follow-up to #51 (case-sensitive archive names). 

Simplify SerializedFile handling to be case-sensitive for the actual filename.
I'm not sure the origin of the case-insensitive matching but this seems unnecessary, and muddies the
expectations about how references and file naming works.

The only case I'm aware of where Unity messes with the case is the convention it has of making 
AssetBundle names lower case.  (e.g. the Unity Archive is lower case regardless of the string
used in the AssetBundle name).  This PR doesn't impact that legacy behavior.

## Changes

- Dropped `ToLowerInvariant()` at every SerializedFile-name key site:
  - a file's own name and its external-reference path basenames
    (`SerializedFileSQLiteWriter`)
  - the SBP/Addressables scene `.sharedAssets` name and the scene file from
    `m_SceneHashes` (`SerializedFileSQLiteWriter`, `AssetBundleHandler`)
  - the `<contenthash>.cf` keys used for ContentLayout linkage and the content-file
    dependency map (`ContentLayoutSQLWriter`, `ContentFileDependencyMap`)
- Updated the related comments.
- Dangling-ref stub names now preserve the referenced case instead of being lowercased.
- No schema change: `serialized_files.name` already stored the actual relative path;
  only the internal matching key changed.

## Testing

- `dotnet test` — full suite green (UnityFileSystem 425/10 skipped, Analyzer 62,
  UnityDataTool 259).
- The suite exercises AssetBundles across Unity 2019–2023, player builds, both
  scene-bundle pipelines (BuildPipeline and SBP/Addressables), ContentDirectory,
  dangling-refs and find-refs. Everything still resolves, confirming the test data has no
  case mismatch between references and the files they target (CAB/`.cf` names are
  lowercase hex, player external references match their on-disk names, and the built-in
  dangling targets `unity_builtin_extra` / `unity default resources` still match).
