### PR TITLE
[#65] Print GUID and Hash128 as single hex strings in dump output

### DIFF
--- a/Documentation/analyze-examples.md
+++ b/Documentation/analyze-examples.md
@@ -117,8 +117,7 @@ This is an example MonoScript from a `UnityDataTool dump` of a Serialized File:
 ID: -5763254701832525334 (ClassID: 115) MonoScript
   m_Name (string) SpriteSkin
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-  ...
+  m_PropertiesHash (Hash128) 4ce2fab3c132c26713e5cd3f58f2e229
   m_ClassName (string) SpriteSkin
   m_Namespace (string) UnityEngine.U2D.Animation
   m_AssemblyName (string) Unity.2D.Animation.Runtime

--- a/TextDumper/TextDumperTool.cs
+++ b/TextDumper/TextDumperTool.cs
@@ -297,6 +297,14 @@ public class TextDumperTool
                 // Skip child nodes as they were already processed here.
                 skipChildren = true;
             }
+            else if (TryReadCompoundValue(node, ref offset, out var compoundValue))
+            {
+                m_StringBuilder.Append(' ');
+                m_StringBuilder.Append(compoundValue);
+
+                // Skip child nodes as they were already processed here.
+                skipChildren = true;
+            }
 
             m_Writer.WriteLine(m_StringBuilder);
             m_StringBuilder.Clear();
@@ -505,6 +513,52 @@ public class TextDumperTool
         foreach (var child in refTypeRoot.Children)
         {
             RecursiveDump(child, ref offset, level + 1);
+        }
+
+        return true;
+    }
+
+    // Compound types that are more readable printed as a single value than as their serialized
+    // fields, similarly to strings. To support another type, add a case matching its type name and
+    // serialized layout, returning the formatted value and advancing offset past the data.
+    bool TryReadCompoundValue(TypeTreeNode node, ref long offset, out string value)
+    {
+        switch (node.Type)
+        {
+            // A GUID is serialized as 4 uint32 values.
+            case "GUID" when HasUniformLeafChildren(node, 4, 4):
+                value = GuidHelper.FormatUnityGuid(
+                    m_Reader.ReadUInt32(offset),
+                    m_Reader.ReadUInt32(offset + 4),
+                    m_Reader.ReadUInt32(offset + 8),
+                    m_Reader.ReadUInt32(offset + 12));
+                offset += 16;
+                return true;
+
+            // A Hash128 is serialized as 16 bytes.
+            case "Hash128" when HasUniformLeafChildren(node, 16, 1):
+                var bytes = new byte[16];
+                m_Reader.ReadArray(offset, 16, bytes);
+                value = GuidHelper.FormatUnityHash128(bytes);
+                offset += 16;
+                return true;
+        }
+
+        value = null;
+        return false;
+    }
+
+    // Confirms a compound type has the exact layout expected by TryReadCompoundValue, so that an
+    // unrelated type reusing the same name falls back to the generic field-by-field dump.
+    static bool HasUniformLeafChildren(TypeTreeNode node, int count, int size)
+    {
+        if (node.Children.Count != count)
+            return false;
+
+        foreach (var child in node.Children)
+        {
+            if (!child.IsLeaf || child.Size != size)
+                return false;
         }
 
         return true;

--- a/UnityDataTool.Tests/DumpTests.cs
+++ b/UnityDataTool.Tests/DumpTests.cs
@@ -16,6 +16,7 @@ public class DumpTests
     private string m_NoTypeTreeSerializedFilePath;
     private string m_NoTypeTreeArchivePath;
     private string m_SerializationDemoBundlePath;
+    private string m_ContentDirectoryBuildReportPath;
 
     [OneTimeSetUp]
     public void OneTimeSetup()
@@ -27,6 +28,7 @@ public class DumpTests
         m_NoTypeTreeSerializedFilePath = Path.Combine(m_TestDataFolder, "PlayerNoTypeTree", "level0");
         m_NoTypeTreeArchivePath = Path.Combine(m_TestDataFolder, "AssetBundleTypeTreeVariations", "AssetBundle-NoTypeTree", "small.bundle");
         m_SerializationDemoBundlePath = Path.Combine(m_TestDataFolder, "LeadingEdgeBuilds", "AssetBundles", "serializationdemo");
+        m_ContentDirectoryBuildReportPath = Path.Combine(m_TestDataFolder, "LeadingEdgeBuilds", "BuildReport-ContentDirectory", "f64157fb08bb9f645971d39c1203bd03.buildreport");
     }
 
     [Test]
@@ -308,5 +310,35 @@ public class DumpTests
         // Int array of 512 values (0..511). Check the header and a slice of the sequence.
         Assert.That(output, Does.Contain("Array<int>[512]"));
         Assert.That(output, Does.Contain("293, 294, 295, 296,"));
+    }
+
+    // GUID and Hash128 fields are printed as a single hex string instead of their serialized fields.
+    // The expected values can be verified independently: buildSessionGUID matches the build report
+    // file name, and the Scene1 sourceAssetGUID matches Assets/Scenes/Scene1.unity.meta in the
+    // LeadingEdge project.
+    [Test]
+    public async Task Dump_Stdout_BuildReport_PrintsGuidAndHash128AsHexStrings()
+    {
+        using var sw = new StringWriter();
+        var currentOut = Console.Out;
+        try
+        {
+            Console.SetOut(sw);
+            Assert.AreEqual(0, await Program.Main(new string[] { "dump", m_ContentDirectoryBuildReportPath, "--stdout" }));
+        }
+        finally
+        {
+            Console.SetOut(currentOut);
+        }
+
+        var output = sw.ToString();
+
+        Assert.That(output, Does.Contain("buildSessionGUID (GUID) f64157fb08bb9f645971d39c1203bd03"));
+        Assert.That(output, Does.Contain("sourceAssetGUID (GUID) 162c015549f8733449ac70ae78ad3aa5"));
+        Assert.That(output, Does.Contain("buildManifestHash (Hash128) baff06b928d147276f2245dd3b19216a"));
+
+        // The individual fields of these compound types are no longer dumped.
+        Assert.That(output, Does.Not.Contain("data[0] (unsigned int)"));
+        Assert.That(output, Does.Not.Contain("bytes[0] (UInt8)"));
     }
 }

--- a/UnityDataTool.Tests/ExpectedData/2019.4.0f1/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2019.4.0f1/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -27148,23 +27148,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 5
-    bytes[1] (UInt8) 61
-    bytes[2] (UInt8) 135
-    bytes[3] (UInt8) 226
-    bytes[4] (UInt8) 11
-    bytes[5] (UInt8) 136
-    bytes[6] (UInt8) 110
-    bytes[7] (UInt8) 198
-    bytes[8] (UInt8) 240
-    bytes[9] (UInt8) 145
-    bytes[10] (UInt8) 18
-    bytes[11] (UInt8) 73
-    bytes[12] (UInt8) 18
-    bytes[13] (UInt8) 65
-    bytes[14] (UInt8) 27
-    bytes[15] (UInt8) 13
+  m_PropertiesHash (Hash128) 053d87e20b886ec6f091124912411b0d
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp.dll

--- a/UnityDataTool.Tests/ExpectedData/2019.4.0f1/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2019.4.0f1/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -27148,23 +27148,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 5
-    bytes[1] (UInt8) 61
-    bytes[2] (UInt8) 135
-    bytes[3] (UInt8) 226
-    bytes[4] (UInt8) 11
-    bytes[5] (UInt8) 136
-    bytes[6] (UInt8) 110
-    bytes[7] (UInt8) 198
-    bytes[8] (UInt8) 240
-    bytes[9] (UInt8) 145
-    bytes[10] (UInt8) 18
-    bytes[11] (UInt8) 73
-    bytes[12] (UInt8) 18
-    bytes[13] (UInt8) 65
-    bytes[14] (UInt8) 27
-    bytes[15] (UInt8) 13
+  m_PropertiesHash (Hash128) 053d87e20b886ec6f091124912411b0d
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp.dll

--- a/UnityDataTool.Tests/ExpectedData/2020.3.0f1/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2020.3.0f1/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -1462,23 +1462,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 192
-                      bytes[1] (UInt8) 166
-                      bytes[2] (UInt8) 166
-                      bytes[3] (UInt8) 93
-                      bytes[4] (UInt8) 16
-                      bytes[5] (UInt8) 38
-                      bytes[6] (UInt8) 224
-                      bytes[7] (UInt8) 145
-                      bytes[8] (UInt8) 138
-                      bytes[9] (UInt8) 53
-                      bytes[10] (UInt8) 221
-                      bytes[11] (UInt8) 144
-                      bytes[12] (UInt8) 92
-                      bytes[13] (UInt8) 190
-                      bytes[14] (UInt8) 87
-                      bytes[15] (UInt8) 111
+                    data[0] (Hash128) c0a6a65d1026e0918a35dd905cbe576f
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -3836,23 +3820,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 8
-                      bytes[1] (UInt8) 241
-                      bytes[2] (UInt8) 57
-                      bytes[3] (UInt8) 243
-                      bytes[4] (UInt8) 51
-                      bytes[5] (UInt8) 86
-                      bytes[6] (UInt8) 239
-                      bytes[7] (UInt8) 57
-                      bytes[8] (UInt8) 119
-                      bytes[9] (UInt8) 191
-                      bytes[10] (UInt8) 32
-                      bytes[11] (UInt8) 23
-                      bytes[12] (UInt8) 250
-                      bytes[13] (UInt8) 71
-                      bytes[14] (UInt8) 215
-                      bytes[15] (UInt8) 69
+                    data[0] (Hash128) 08f139f33356ef3977bf2017fa47d745
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -7664,23 +7632,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 111
-                      bytes[1] (UInt8) 194
-                      bytes[2] (UInt8) 173
-                      bytes[3] (UInt8) 16
-                      bytes[4] (UInt8) 60
-                      bytes[5] (UInt8) 116
-                      bytes[6] (UInt8) 35
-                      bytes[7] (UInt8) 216
-                      bytes[8] (UInt8) 129
-                      bytes[9] (UInt8) 74
-                      bytes[10] (UInt8) 47
-                      bytes[11] (UInt8) 70
-                      bytes[12] (UInt8) 152
-                      bytes[13] (UInt8) 169
-                      bytes[14] (UInt8) 173
-                      bytes[15] (UInt8) 17
+                    data[0] (Hash128) 6fc2ad103c7423d8814a2f4698a9ad11
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -8279,23 +8231,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 178
-                      bytes[1] (UInt8) 224
-                      bytes[2] (UInt8) 137
-                      bytes[3] (UInt8) 74
-                      bytes[4] (UInt8) 127
-                      bytes[5] (UInt8) 162
-                      bytes[6] (UInt8) 27
-                      bytes[7] (UInt8) 135
-                      bytes[8] (UInt8) 75
-                      bytes[9] (UInt8) 81
-                      bytes[10] (UInt8) 206
-                      bytes[11] (UInt8) 224
-                      bytes[12] (UInt8) 107
-                      bytes[13] (UInt8) 223
-                      bytes[14] (UInt8) 60
-                      bytes[15] (UInt8) 205
+                    data[0] (Hash128) b2e0894a7fa21b874b51cee06bdf3ccd
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -9619,23 +9555,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 150
-                      bytes[1] (UInt8) 230
-                      bytes[2] (UInt8) 29
-                      bytes[3] (UInt8) 163
-                      bytes[4] (UInt8) 125
-                      bytes[5] (UInt8) 154
-                      bytes[6] (UInt8) 64
-                      bytes[7] (UInt8) 168
-                      bytes[8] (UInt8) 45
-                      bytes[9] (UInt8) 247
-                      bytes[10] (UInt8) 95
-                      bytes[11] (UInt8) 153
-                      bytes[12] (UInt8) 86
-                      bytes[13] (UInt8) 66
-                      bytes[14] (UInt8) 106
-                      bytes[15] (UInt8) 26
+                    data[0] (Hash128) 96e61da37d9a40a82df75f9956426a1a
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -11906,23 +11826,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 31
-                      bytes[1] (UInt8) 19
-                      bytes[2] (UInt8) 106
-                      bytes[3] (UInt8) 189
-                      bytes[4] (UInt8) 195
-                      bytes[5] (UInt8) 151
-                      bytes[6] (UInt8) 128
-                      bytes[7] (UInt8) 190
-                      bytes[8] (UInt8) 61
-                      bytes[9] (UInt8) 154
-                      bytes[10] (UInt8) 74
-                      bytes[11] (UInt8) 25
-                      bytes[12] (UInt8) 150
-                      bytes[13] (UInt8) 79
-                      bytes[14] (UInt8) 149
-                      bytes[15] (UInt8) 82
+                    data[0] (Hash128) 1f136abdc39780be3d9a4a19964f9552
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -14786,23 +14690,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 184
-                      bytes[1] (UInt8) 36
-                      bytes[2] (UInt8) 79
-                      bytes[3] (UInt8) 73
-                      bytes[4] (UInt8) 119
-                      bytes[5] (UInt8) 102
-                      bytes[6] (UInt8) 188
-                      bytes[7] (UInt8) 79
-                      bytes[8] (UInt8) 248
-                      bytes[9] (UInt8) 33
-                      bytes[10] (UInt8) 219
-                      bytes[11] (UInt8) 217
-                      bytes[12] (UInt8) 125
-                      bytes[13] (UInt8) 90
-                      bytes[14] (UInt8) 150
-                      bytes[15] (UInt8) 50
+                    data[0] (Hash128) b8244f497766bc4ff821dbd97d5a9632
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -16790,23 +16678,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 5
-    bytes[1] (UInt8) 61
-    bytes[2] (UInt8) 135
-    bytes[3] (UInt8) 226
-    bytes[4] (UInt8) 11
-    bytes[5] (UInt8) 136
-    bytes[6] (UInt8) 110
-    bytes[7] (UInt8) 198
-    bytes[8] (UInt8) 240
-    bytes[9] (UInt8) 145
-    bytes[10] (UInt8) 18
-    bytes[11] (UInt8) 73
-    bytes[12] (UInt8) 18
-    bytes[13] (UInt8) 65
-    bytes[14] (UInt8) 27
-    bytes[15] (UInt8) 13
+  m_PropertiesHash (Hash128) 053d87e20b886ec6f091124912411b0d
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp.dll
@@ -17230,23 +17102,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 37
-                      bytes[1] (UInt8) 0
-                      bytes[2] (UInt8) 151
-                      bytes[3] (UInt8) 139
-                      bytes[4] (UInt8) 130
-                      bytes[5] (UInt8) 12
-                      bytes[6] (UInt8) 115
-                      bytes[7] (UInt8) 38
-                      bytes[8] (UInt8) 52
-                      bytes[9] (UInt8) 212
-                      bytes[10] (UInt8) 248
-                      bytes[11] (UInt8) 183
-                      bytes[12] (UInt8) 15
-                      bytes[13] (UInt8) 180
-                      bytes[14] (UInt8) 51
-                      bytes[15] (UInt8) 154
+                    data[0] (Hash128) 2500978b820c732634d4f8b70fb4339a
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -27021,23 +26877,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 163
-                      bytes[1] (UInt8) 229
-                      bytes[2] (UInt8) 86
-                      bytes[3] (UInt8) 0
-                      bytes[4] (UInt8) 254
-                      bytes[5] (UInt8) 128
-                      bytes[6] (UInt8) 13
-                      bytes[7] (UInt8) 139
-                      bytes[8] (UInt8) 74
-                      bytes[9] (UInt8) 193
-                      bytes[10] (UInt8) 141
-                      bytes[11] (UInt8) 154
-                      bytes[12] (UInt8) 106
-                      bytes[13] (UInt8) 172
-                      bytes[14] (UInt8) 121
-                      bytes[15] (UInt8) 58
+                    data[0] (Hash128) a3e55600fe800d8b4ac18d9a6aac793a
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -41139,23 +40979,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 37
-                      bytes[1] (UInt8) 82
-                      bytes[2] (UInt8) 64
-                      bytes[3] (UInt8) 58
-                      bytes[4] (UInt8) 196
-                      bytes[5] (UInt8) 49
-                      bytes[6] (UInt8) 80
-                      bytes[7] (UInt8) 199
-                      bytes[8] (UInt8) 80
-                      bytes[9] (UInt8) 178
-                      bytes[10] (UInt8) 62
-                      bytes[11] (UInt8) 99
-                      bytes[12] (UInt8) 151
-                      bytes[13] (UInt8) 10
-                      bytes[14] (UInt8) 65
-                      bytes[15] (UInt8) 220
+                    data[0] (Hash128) 2552403ac43150c750b23e63970a41dc
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -41973,23 +41797,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 70
-                      bytes[1] (UInt8) 6
-                      bytes[2] (UInt8) 36
-                      bytes[3] (UInt8) 66
-                      bytes[4] (UInt8) 238
-                      bytes[5] (UInt8) 113
-                      bytes[6] (UInt8) 254
-                      bytes[7] (UInt8) 248
-                      bytes[8] (UInt8) 188
-                      bytes[9] (UInt8) 40
-                      bytes[10] (UInt8) 100
-                      bytes[11] (UInt8) 10
-                      bytes[12] (UInt8) 38
-                      bytes[13] (UInt8) 202
-                      bytes[14] (UInt8) 194
-                      bytes[15] (UInt8) 198
+                    data[0] (Hash128) 46062442ee71fef8bc28640a26cac2c6
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -46956,23 +46764,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 81
-                      bytes[1] (UInt8) 63
-                      bytes[2] (UInt8) 164
-                      bytes[3] (UInt8) 175
-                      bytes[4] (UInt8) 248
-                      bytes[5] (UInt8) 156
-                      bytes[6] (UInt8) 129
-                      bytes[7] (UInt8) 98
-                      bytes[8] (UInt8) 244
-                      bytes[9] (UInt8) 150
-                      bytes[10] (UInt8) 251
-                      bytes[11] (UInt8) 87
-                      bytes[12] (UInt8) 231
-                      bytes[13] (UInt8) 97
-                      bytes[14] (UInt8) 195
-                      bytes[15] (UInt8) 124
+                    data[0] (Hash128) 513fa4aff89c8162f496fb57e761c37c
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -56174,23 +55966,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 236
-                      bytes[1] (UInt8) 245
-                      bytes[2] (UInt8) 3
-                      bytes[3] (UInt8) 3
-                      bytes[4] (UInt8) 250
-                      bytes[5] (UInt8) 223
-                      bytes[6] (UInt8) 129
-                      bytes[7] (UInt8) 184
-                      bytes[8] (UInt8) 17
-                      bytes[9] (UInt8) 18
-                      bytes[10] (UInt8) 78
-                      bytes[11] (UInt8) 108
-                      bytes[12] (UInt8) 28
-                      bytes[13] (UInt8) 159
-                      bytes[14] (UInt8) 106
-                      bytes[15] (UInt8) 7
+                    data[0] (Hash128) ecf50303fadf81b811124e6c1c9f6a07
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -66386,23 +66162,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 78
-                      bytes[1] (UInt8) 190
-                      bytes[2] (UInt8) 184
-                      bytes[3] (UInt8) 178
-                      bytes[4] (UInt8) 117
-                      bytes[5] (UInt8) 234
-                      bytes[6] (UInt8) 114
-                      bytes[7] (UInt8) 120
-                      bytes[8] (UInt8) 158
-                      bytes[9] (UInt8) 62
-                      bytes[10] (UInt8) 233
-                      bytes[11] (UInt8) 9
-                      bytes[12] (UInt8) 115
-                      bytes[13] (UInt8) 144
-                      bytes[14] (UInt8) 105
-                      bytes[15] (UInt8) 19
+                    data[0] (Hash128) 4ebeb8b275ea72789e3ee90973906913
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14

--- a/UnityDataTool.Tests/ExpectedData/2020.3.0f1/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2020.3.0f1/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -1462,23 +1462,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 192
-                      bytes[1] (UInt8) 166
-                      bytes[2] (UInt8) 166
-                      bytes[3] (UInt8) 93
-                      bytes[4] (UInt8) 16
-                      bytes[5] (UInt8) 38
-                      bytes[6] (UInt8) 224
-                      bytes[7] (UInt8) 145
-                      bytes[8] (UInt8) 138
-                      bytes[9] (UInt8) 53
-                      bytes[10] (UInt8) 221
-                      bytes[11] (UInt8) 144
-                      bytes[12] (UInt8) 92
-                      bytes[13] (UInt8) 190
-                      bytes[14] (UInt8) 87
-                      bytes[15] (UInt8) 111
+                    data[0] (Hash128) c0a6a65d1026e0918a35dd905cbe576f
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -3836,23 +3820,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 8
-                      bytes[1] (UInt8) 241
-                      bytes[2] (UInt8) 57
-                      bytes[3] (UInt8) 243
-                      bytes[4] (UInt8) 51
-                      bytes[5] (UInt8) 86
-                      bytes[6] (UInt8) 239
-                      bytes[7] (UInt8) 57
-                      bytes[8] (UInt8) 119
-                      bytes[9] (UInt8) 191
-                      bytes[10] (UInt8) 32
-                      bytes[11] (UInt8) 23
-                      bytes[12] (UInt8) 250
-                      bytes[13] (UInt8) 71
-                      bytes[14] (UInt8) 215
-                      bytes[15] (UInt8) 69
+                    data[0] (Hash128) 08f139f33356ef3977bf2017fa47d745
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -7664,23 +7632,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 111
-                      bytes[1] (UInt8) 194
-                      bytes[2] (UInt8) 173
-                      bytes[3] (UInt8) 16
-                      bytes[4] (UInt8) 60
-                      bytes[5] (UInt8) 116
-                      bytes[6] (UInt8) 35
-                      bytes[7] (UInt8) 216
-                      bytes[8] (UInt8) 129
-                      bytes[9] (UInt8) 74
-                      bytes[10] (UInt8) 47
-                      bytes[11] (UInt8) 70
-                      bytes[12] (UInt8) 152
-                      bytes[13] (UInt8) 169
-                      bytes[14] (UInt8) 173
-                      bytes[15] (UInt8) 17
+                    data[0] (Hash128) 6fc2ad103c7423d8814a2f4698a9ad11
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -8279,23 +8231,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 178
-                      bytes[1] (UInt8) 224
-                      bytes[2] (UInt8) 137
-                      bytes[3] (UInt8) 74
-                      bytes[4] (UInt8) 127
-                      bytes[5] (UInt8) 162
-                      bytes[6] (UInt8) 27
-                      bytes[7] (UInt8) 135
-                      bytes[8] (UInt8) 75
-                      bytes[9] (UInt8) 81
-                      bytes[10] (UInt8) 206
-                      bytes[11] (UInt8) 224
-                      bytes[12] (UInt8) 107
-                      bytes[13] (UInt8) 223
-                      bytes[14] (UInt8) 60
-                      bytes[15] (UInt8) 205
+                    data[0] (Hash128) b2e0894a7fa21b874b51cee06bdf3ccd
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -9619,23 +9555,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 150
-                      bytes[1] (UInt8) 230
-                      bytes[2] (UInt8) 29
-                      bytes[3] (UInt8) 163
-                      bytes[4] (UInt8) 125
-                      bytes[5] (UInt8) 154
-                      bytes[6] (UInt8) 64
-                      bytes[7] (UInt8) 168
-                      bytes[8] (UInt8) 45
-                      bytes[9] (UInt8) 247
-                      bytes[10] (UInt8) 95
-                      bytes[11] (UInt8) 153
-                      bytes[12] (UInt8) 86
-                      bytes[13] (UInt8) 66
-                      bytes[14] (UInt8) 106
-                      bytes[15] (UInt8) 26
+                    data[0] (Hash128) 96e61da37d9a40a82df75f9956426a1a
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -11906,23 +11826,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 31
-                      bytes[1] (UInt8) 19
-                      bytes[2] (UInt8) 106
-                      bytes[3] (UInt8) 189
-                      bytes[4] (UInt8) 195
-                      bytes[5] (UInt8) 151
-                      bytes[6] (UInt8) 128
-                      bytes[7] (UInt8) 190
-                      bytes[8] (UInt8) 61
-                      bytes[9] (UInt8) 154
-                      bytes[10] (UInt8) 74
-                      bytes[11] (UInt8) 25
-                      bytes[12] (UInt8) 150
-                      bytes[13] (UInt8) 79
-                      bytes[14] (UInt8) 149
-                      bytes[15] (UInt8) 82
+                    data[0] (Hash128) 1f136abdc39780be3d9a4a19964f9552
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -14786,23 +14690,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 184
-                      bytes[1] (UInt8) 36
-                      bytes[2] (UInt8) 79
-                      bytes[3] (UInt8) 73
-                      bytes[4] (UInt8) 119
-                      bytes[5] (UInt8) 102
-                      bytes[6] (UInt8) 188
-                      bytes[7] (UInt8) 79
-                      bytes[8] (UInt8) 248
-                      bytes[9] (UInt8) 33
-                      bytes[10] (UInt8) 219
-                      bytes[11] (UInt8) 217
-                      bytes[12] (UInt8) 125
-                      bytes[13] (UInt8) 90
-                      bytes[14] (UInt8) 150
-                      bytes[15] (UInt8) 50
+                    data[0] (Hash128) b8244f497766bc4ff821dbd97d5a9632
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -16790,23 +16678,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 5
-    bytes[1] (UInt8) 61
-    bytes[2] (UInt8) 135
-    bytes[3] (UInt8) 226
-    bytes[4] (UInt8) 11
-    bytes[5] (UInt8) 136
-    bytes[6] (UInt8) 110
-    bytes[7] (UInt8) 198
-    bytes[8] (UInt8) 240
-    bytes[9] (UInt8) 145
-    bytes[10] (UInt8) 18
-    bytes[11] (UInt8) 73
-    bytes[12] (UInt8) 18
-    bytes[13] (UInt8) 65
-    bytes[14] (UInt8) 27
-    bytes[15] (UInt8) 13
+  m_PropertiesHash (Hash128) 053d87e20b886ec6f091124912411b0d
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp.dll
@@ -17230,23 +17102,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 37
-                      bytes[1] (UInt8) 0
-                      bytes[2] (UInt8) 151
-                      bytes[3] (UInt8) 139
-                      bytes[4] (UInt8) 130
-                      bytes[5] (UInt8) 12
-                      bytes[6] (UInt8) 115
-                      bytes[7] (UInt8) 38
-                      bytes[8] (UInt8) 52
-                      bytes[9] (UInt8) 212
-                      bytes[10] (UInt8) 248
-                      bytes[11] (UInt8) 183
-                      bytes[12] (UInt8) 15
-                      bytes[13] (UInt8) 180
-                      bytes[14] (UInt8) 51
-                      bytes[15] (UInt8) 154
+                    data[0] (Hash128) 2500978b820c732634d4f8b70fb4339a
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -27021,23 +26877,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 163
-                      bytes[1] (UInt8) 229
-                      bytes[2] (UInt8) 86
-                      bytes[3] (UInt8) 0
-                      bytes[4] (UInt8) 254
-                      bytes[5] (UInt8) 128
-                      bytes[6] (UInt8) 13
-                      bytes[7] (UInt8) 139
-                      bytes[8] (UInt8) 74
-                      bytes[9] (UInt8) 193
-                      bytes[10] (UInt8) 141
-                      bytes[11] (UInt8) 154
-                      bytes[12] (UInt8) 106
-                      bytes[13] (UInt8) 172
-                      bytes[14] (UInt8) 121
-                      bytes[15] (UInt8) 58
+                    data[0] (Hash128) a3e55600fe800d8b4ac18d9a6aac793a
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -41139,23 +40979,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 37
-                      bytes[1] (UInt8) 82
-                      bytes[2] (UInt8) 64
-                      bytes[3] (UInt8) 58
-                      bytes[4] (UInt8) 196
-                      bytes[5] (UInt8) 49
-                      bytes[6] (UInt8) 80
-                      bytes[7] (UInt8) 199
-                      bytes[8] (UInt8) 80
-                      bytes[9] (UInt8) 178
-                      bytes[10] (UInt8) 62
-                      bytes[11] (UInt8) 99
-                      bytes[12] (UInt8) 151
-                      bytes[13] (UInt8) 10
-                      bytes[14] (UInt8) 65
-                      bytes[15] (UInt8) 220
+                    data[0] (Hash128) 2552403ac43150c750b23e63970a41dc
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -41973,23 +41797,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 70
-                      bytes[1] (UInt8) 6
-                      bytes[2] (UInt8) 36
-                      bytes[3] (UInt8) 66
-                      bytes[4] (UInt8) 238
-                      bytes[5] (UInt8) 113
-                      bytes[6] (UInt8) 254
-                      bytes[7] (UInt8) 248
-                      bytes[8] (UInt8) 188
-                      bytes[9] (UInt8) 40
-                      bytes[10] (UInt8) 100
-                      bytes[11] (UInt8) 10
-                      bytes[12] (UInt8) 38
-                      bytes[13] (UInt8) 202
-                      bytes[14] (UInt8) 194
-                      bytes[15] (UInt8) 198
+                    data[0] (Hash128) 46062442ee71fef8bc28640a26cac2c6
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -46956,23 +46764,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 81
-                      bytes[1] (UInt8) 63
-                      bytes[2] (UInt8) 164
-                      bytes[3] (UInt8) 175
-                      bytes[4] (UInt8) 248
-                      bytes[5] (UInt8) 156
-                      bytes[6] (UInt8) 129
-                      bytes[7] (UInt8) 98
-                      bytes[8] (UInt8) 244
-                      bytes[9] (UInt8) 150
-                      bytes[10] (UInt8) 251
-                      bytes[11] (UInt8) 87
-                      bytes[12] (UInt8) 231
-                      bytes[13] (UInt8) 97
-                      bytes[14] (UInt8) 195
-                      bytes[15] (UInt8) 124
+                    data[0] (Hash128) 513fa4aff89c8162f496fb57e761c37c
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -56174,23 +55966,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 236
-                      bytes[1] (UInt8) 245
-                      bytes[2] (UInt8) 3
-                      bytes[3] (UInt8) 3
-                      bytes[4] (UInt8) 250
-                      bytes[5] (UInt8) 223
-                      bytes[6] (UInt8) 129
-                      bytes[7] (UInt8) 184
-                      bytes[8] (UInt8) 17
-                      bytes[9] (UInt8) 18
-                      bytes[10] (UInt8) 78
-                      bytes[11] (UInt8) 108
-                      bytes[12] (UInt8) 28
-                      bytes[13] (UInt8) 159
-                      bytes[14] (UInt8) 106
-                      bytes[15] (UInt8) 7
+                    data[0] (Hash128) ecf50303fadf81b811124e6c1c9f6a07
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -66386,23 +66162,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 78
-                      bytes[1] (UInt8) 190
-                      bytes[2] (UInt8) 184
-                      bytes[3] (UInt8) 178
-                      bytes[4] (UInt8) 117
-                      bytes[5] (UInt8) 234
-                      bytes[6] (UInt8) 114
-                      bytes[7] (UInt8) 120
-                      bytes[8] (UInt8) 158
-                      bytes[9] (UInt8) 62
-                      bytes[10] (UInt8) 233
-                      bytes[11] (UInt8) 9
-                      bytes[12] (UInt8) 115
-                      bytes[13] (UInt8) 144
-                      bytes[14] (UInt8) 105
-                      bytes[15] (UInt8) 19
+                    data[0] (Hash128) 4ebeb8b275ea72789e3ee90973906913
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14

--- a/UnityDataTool.Tests/ExpectedData/2021.3.0f1/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2021.3.0f1/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -1477,23 +1477,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 167
-                      bytes[1] (UInt8) 175
-                      bytes[2] (UInt8) 81
-                      bytes[3] (UInt8) 66
-                      bytes[4] (UInt8) 248
-                      bytes[5] (UInt8) 195
-                      bytes[6] (UInt8) 29
-                      bytes[7] (UInt8) 251
-                      bytes[8] (UInt8) 42
-                      bytes[9] (UInt8) 170
-                      bytes[10] (UInt8) 144
-                      bytes[11] (UInt8) 43
-                      bytes[12] (UInt8) 27
-                      bytes[13] (UInt8) 157
-                      bytes[14] (UInt8) 16
-                      bytes[15] (UInt8) 54
+                    data[0] (Hash128) a7af5142f8c31dfb2aaa902b1b9d1036
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -2414,23 +2398,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 87
-                      bytes[1] (UInt8) 129
-                      bytes[2] (UInt8) 234
-                      bytes[3] (UInt8) 65
-                      bytes[4] (UInt8) 244
-                      bytes[5] (UInt8) 27
-                      bytes[6] (UInt8) 69
-                      bytes[7] (UInt8) 216
-                      bytes[8] (UInt8) 40
-                      bytes[9] (UInt8) 106
-                      bytes[10] (UInt8) 110
-                      bytes[11] (UInt8) 164
-                      bytes[12] (UInt8) 245
-                      bytes[13] (UInt8) 78
-                      bytes[14] (UInt8) 57
-                      bytes[15] (UInt8) 225
+                    data[0] (Hash128) 5781ea41f41b45d8286a6ea4f54e39e1
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -3808,23 +3776,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 11
-                      bytes[1] (UInt8) 155
-                      bytes[2] (UInt8) 93
-                      bytes[3] (UInt8) 43
-                      bytes[4] (UInt8) 188
-                      bytes[5] (UInt8) 118
-                      bytes[6] (UInt8) 115
-                      bytes[7] (UInt8) 128
-                      bytes[8] (UInt8) 128
-                      bytes[9] (UInt8) 0
-                      bytes[10] (UInt8) 199
-                      bytes[11] (UInt8) 119
-                      bytes[12] (UInt8) 156
-                      bytes[13] (UInt8) 19
-                      bytes[14] (UInt8) 241
-                      bytes[15] (UInt8) 121
+                    data[0] (Hash128) 0b9b5d2bbc7673808000c7779c13f179
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -4449,23 +4401,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 84
-                      bytes[1] (UInt8) 217
-                      bytes[2] (UInt8) 116
-                      bytes[3] (UInt8) 42
-                      bytes[4] (UInt8) 80
-                      bytes[5] (UInt8) 139
-                      bytes[6] (UInt8) 149
-                      bytes[7] (UInt8) 199
-                      bytes[8] (UInt8) 19
-                      bytes[9] (UInt8) 161
-                      bytes[10] (UInt8) 105
-                      bytes[11] (UInt8) 210
-                      bytes[12] (UInt8) 80
-                      bytes[13] (UInt8) 63
-                      bytes[14] (UInt8) 138
-                      bytes[15] (UInt8) 160
+                    data[0] (Hash128) 54d9742a508b95c713a169d2503f8aa0
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -5221,23 +5157,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 229
-                      bytes[1] (UInt8) 174
-                      bytes[2] (UInt8) 229
-                      bytes[3] (UInt8) 28
-                      bytes[4] (UInt8) 11
-                      bytes[5] (UInt8) 114
-                      bytes[6] (UInt8) 120
-                      bytes[7] (UInt8) 89
-                      bytes[8] (UInt8) 214
-                      bytes[9] (UInt8) 58
-                      bytes[10] (UInt8) 7
-                      bytes[11] (UInt8) 120
-                      bytes[12] (UInt8) 95
-                      bytes[13] (UInt8) 135
-                      bytes[14] (UInt8) 101
-                      bytes[15] (UInt8) 45
+                    data[0] (Hash128) e5aee51c0b727859d63a07785f87652d
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -6158,23 +6078,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 141
-                      bytes[1] (UInt8) 79
-                      bytes[2] (UInt8) 131
-                      bytes[3] (UInt8) 105
-                      bytes[4] (UInt8) 109
-                      bytes[5] (UInt8) 85
-                      bytes[6] (UInt8) 233
-                      bytes[7] (UInt8) 74
-                      bytes[8] (UInt8) 38
-                      bytes[9] (UInt8) 243
-                      bytes[10] (UInt8) 91
-                      bytes[11] (UInt8) 235
-                      bytes[12] (UInt8) 156
-                      bytes[13] (UInt8) 137
-                      bytes[14] (UInt8) 87
-                      bytes[15] (UInt8) 36
+                    data[0] (Hash128) 8d4f83696d55e94a26f35beb9c895724
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -7342,23 +7246,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 14
-                      bytes[1] (UInt8) 101
-                      bytes[2] (UInt8) 252
-                      bytes[3] (UInt8) 148
-                      bytes[4] (UInt8) 131
-                      bytes[5] (UInt8) 243
-                      bytes[6] (UInt8) 140
-                      bytes[7] (UInt8) 100
-                      bytes[8] (UInt8) 40
-                      bytes[9] (UInt8) 22
-                      bytes[10] (UInt8) 26
-                      bytes[11] (UInt8) 74
-                      bytes[12] (UInt8) 22
-                      bytes[13] (UInt8) 224
-                      bytes[14] (UInt8) 57
-                      bytes[15] (UInt8) 153
+                    data[0] (Hash128) 0e65fc9483f38c6428161a4a16e03999
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -9429,23 +9317,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 15
-    bytes[1] (UInt8) 113
-    bytes[2] (UInt8) 115
-    bytes[3] (UInt8) 62
-    bytes[4] (UInt8) 27
-    bytes[5] (UInt8) 101
-    bytes[6] (UInt8) 58
-    bytes[7] (UInt8) 215
-    bytes[8] (UInt8) 158
-    bytes[9] (UInt8) 42
-    bytes[10] (UInt8) 252
-    bytes[11] (UInt8) 193
-    bytes[12] (UInt8) 221
-    bytes[13] (UInt8) 6
-    bytes[14] (UInt8) 197
-    bytes[15] (UInt8) 236
+  m_PropertiesHash (Hash128) 0f71733e1b653ad79e2afcc1dd06c5ec
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp.dll
@@ -9869,23 +9741,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 235
-                      bytes[1] (UInt8) 25
-                      bytes[2] (UInt8) 11
-                      bytes[3] (UInt8) 91
-                      bytes[4] (UInt8) 28
-                      bytes[5] (UInt8) 211
-                      bytes[6] (UInt8) 44
-                      bytes[7] (UInt8) 160
-                      bytes[8] (UInt8) 219
-                      bytes[9] (UInt8) 152
-                      bytes[10] (UInt8) 220
-                      bytes[11] (UInt8) 150
-                      bytes[12] (UInt8) 74
-                      bytes[13] (UInt8) 194
-                      bytes[14] (UInt8) 88
-                      bytes[15] (UInt8) 79
+                    data[0] (Hash128) eb190b5b1cd32ca0db98dc964ac2584f
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -11390,23 +11246,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 139
-                      bytes[1] (UInt8) 77
-                      bytes[2] (UInt8) 71
-                      bytes[3] (UInt8) 86
-                      bytes[4] (UInt8) 41
-                      bytes[5] (UInt8) 32
-                      bytes[6] (UInt8) 253
-                      bytes[7] (UInt8) 37
-                      bytes[8] (UInt8) 211
-                      bytes[9] (UInt8) 99
-                      bytes[10] (UInt8) 200
-                      bytes[11] (UInt8) 250
-                      bytes[12] (UInt8) 149
-                      bytes[13] (UInt8) 193
-                      bytes[14] (UInt8) 153
-                      bytes[15] (UInt8) 81
+                    data[0] (Hash128) 8b4d47562920fd25d363c8fa95c19951
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -13733,23 +13573,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 200
-                      bytes[1] (UInt8) 200
-                      bytes[2] (UInt8) 225
-                      bytes[3] (UInt8) 217
-                      bytes[4] (UInt8) 138
-                      bytes[5] (UInt8) 20
-                      bytes[6] (UInt8) 157
-                      bytes[7] (UInt8) 43
-                      bytes[8] (UInt8) 89
-                      bytes[9] (UInt8) 242
-                      bytes[10] (UInt8) 152
-                      bytes[11] (UInt8) 123
-                      bytes[12] (UInt8) 74
-                      bytes[13] (UInt8) 77
-                      bytes[14] (UInt8) 38
-                      bytes[15] (UInt8) 12
+                    data[0] (Hash128) c8c8e1d98a149d2b59f2987b4a4d260c
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -14502,23 +14326,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 7
-                      bytes[1] (UInt8) 21
-                      bytes[2] (UInt8) 181
-                      bytes[3] (UInt8) 160
-                      bytes[4] (UInt8) 14
-                      bytes[5] (UInt8) 45
-                      bytes[6] (UInt8) 197
-                      bytes[7] (UInt8) 232
-                      bytes[8] (UInt8) 73
-                      bytes[9] (UInt8) 95
-                      bytes[10] (UInt8) 84
-                      bytes[11] (UInt8) 149
-                      bytes[12] (UInt8) 242
-                      bytes[13] (UInt8) 141
-                      bytes[14] (UInt8) 3
-                      bytes[15] (UInt8) 31
+                    data[0] (Hash128) 0715b5a00e2dc5e8495f5495f28d031f
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -15682,23 +15490,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 208
-                      bytes[1] (UInt8) 149
-                      bytes[2] (UInt8) 90
-                      bytes[3] (UInt8) 115
-                      bytes[4] (UInt8) 155
-                      bytes[5] (UInt8) 122
-                      bytes[6] (UInt8) 176
-                      bytes[7] (UInt8) 183
-                      bytes[8] (UInt8) 115
-                      bytes[9] (UInt8) 15
-                      bytes[10] (UInt8) 218
-                      bytes[11] (UInt8) 225
-                      bytes[12] (UInt8) 200
-                      bytes[13] (UInt8) 86
-                      bytes[14] (UInt8) 100
-                      bytes[15] (UInt8) 217
+                    data[0] (Hash128) d0955a739b7ab0b7730fdae1c85664d9
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -17194,23 +16986,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 195
-                      bytes[1] (UInt8) 39
-                      bytes[2] (UInt8) 187
-                      bytes[3] (UInt8) 179
-                      bytes[4] (UInt8) 204
-                      bytes[5] (UInt8) 235
-                      bytes[6] (UInt8) 191
-                      bytes[7] (UInt8) 157
-                      bytes[8] (UInt8) 23
-                      bytes[9] (UInt8) 112
-                      bytes[10] (UInt8) 86
-                      bytes[11] (UInt8) 119
-                      bytes[12] (UInt8) 209
-                      bytes[13] (UInt8) 199
-                      bytes[14] (UInt8) 142
-                      bytes[15] (UInt8) 53
+                    data[0] (Hash128) c327bbb3ccebbf9d17705677d1c78e35
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -19108,23 +18884,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 127
-                      bytes[1] (UInt8) 26
-                      bytes[2] (UInt8) 235
-                      bytes[3] (UInt8) 127
-                      bytes[4] (UInt8) 198
-                      bytes[5] (UInt8) 158
-                      bytes[6] (UInt8) 191
-                      bytes[7] (UInt8) 184
-                      bytes[8] (UInt8) 158
-                      bytes[9] (UInt8) 85
-                      bytes[10] (UInt8) 183
-                      bytes[11] (UInt8) 229
-                      bytes[12] (UInt8) 61
-                      bytes[13] (UInt8) 142
-                      bytes[14] (UInt8) 38
-                      bytes[15] (UInt8) 210
+                    data[0] (Hash128) 7f1aeb7fc69ebfb89e55b7e53d8e26d2
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14

--- a/UnityDataTool.Tests/ExpectedData/2021.3.0f1/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2021.3.0f1/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -1477,23 +1477,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 167
-                      bytes[1] (UInt8) 175
-                      bytes[2] (UInt8) 81
-                      bytes[3] (UInt8) 66
-                      bytes[4] (UInt8) 248
-                      bytes[5] (UInt8) 195
-                      bytes[6] (UInt8) 29
-                      bytes[7] (UInt8) 251
-                      bytes[8] (UInt8) 42
-                      bytes[9] (UInt8) 170
-                      bytes[10] (UInt8) 144
-                      bytes[11] (UInt8) 43
-                      bytes[12] (UInt8) 27
-                      bytes[13] (UInt8) 157
-                      bytes[14] (UInt8) 16
-                      bytes[15] (UInt8) 54
+                    data[0] (Hash128) a7af5142f8c31dfb2aaa902b1b9d1036
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -2414,23 +2398,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 87
-                      bytes[1] (UInt8) 129
-                      bytes[2] (UInt8) 234
-                      bytes[3] (UInt8) 65
-                      bytes[4] (UInt8) 244
-                      bytes[5] (UInt8) 27
-                      bytes[6] (UInt8) 69
-                      bytes[7] (UInt8) 216
-                      bytes[8] (UInt8) 40
-                      bytes[9] (UInt8) 106
-                      bytes[10] (UInt8) 110
-                      bytes[11] (UInt8) 164
-                      bytes[12] (UInt8) 245
-                      bytes[13] (UInt8) 78
-                      bytes[14] (UInt8) 57
-                      bytes[15] (UInt8) 225
+                    data[0] (Hash128) 5781ea41f41b45d8286a6ea4f54e39e1
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -3808,23 +3776,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 11
-                      bytes[1] (UInt8) 155
-                      bytes[2] (UInt8) 93
-                      bytes[3] (UInt8) 43
-                      bytes[4] (UInt8) 188
-                      bytes[5] (UInt8) 118
-                      bytes[6] (UInt8) 115
-                      bytes[7] (UInt8) 128
-                      bytes[8] (UInt8) 128
-                      bytes[9] (UInt8) 0
-                      bytes[10] (UInt8) 199
-                      bytes[11] (UInt8) 119
-                      bytes[12] (UInt8) 156
-                      bytes[13] (UInt8) 19
-                      bytes[14] (UInt8) 241
-                      bytes[15] (UInt8) 121
+                    data[0] (Hash128) 0b9b5d2bbc7673808000c7779c13f179
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -4449,23 +4401,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 84
-                      bytes[1] (UInt8) 217
-                      bytes[2] (UInt8) 116
-                      bytes[3] (UInt8) 42
-                      bytes[4] (UInt8) 80
-                      bytes[5] (UInt8) 139
-                      bytes[6] (UInt8) 149
-                      bytes[7] (UInt8) 199
-                      bytes[8] (UInt8) 19
-                      bytes[9] (UInt8) 161
-                      bytes[10] (UInt8) 105
-                      bytes[11] (UInt8) 210
-                      bytes[12] (UInt8) 80
-                      bytes[13] (UInt8) 63
-                      bytes[14] (UInt8) 138
-                      bytes[15] (UInt8) 160
+                    data[0] (Hash128) 54d9742a508b95c713a169d2503f8aa0
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -5221,23 +5157,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 229
-                      bytes[1] (UInt8) 174
-                      bytes[2] (UInt8) 229
-                      bytes[3] (UInt8) 28
-                      bytes[4] (UInt8) 11
-                      bytes[5] (UInt8) 114
-                      bytes[6] (UInt8) 120
-                      bytes[7] (UInt8) 89
-                      bytes[8] (UInt8) 214
-                      bytes[9] (UInt8) 58
-                      bytes[10] (UInt8) 7
-                      bytes[11] (UInt8) 120
-                      bytes[12] (UInt8) 95
-                      bytes[13] (UInt8) 135
-                      bytes[14] (UInt8) 101
-                      bytes[15] (UInt8) 45
+                    data[0] (Hash128) e5aee51c0b727859d63a07785f87652d
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -6158,23 +6078,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 141
-                      bytes[1] (UInt8) 79
-                      bytes[2] (UInt8) 131
-                      bytes[3] (UInt8) 105
-                      bytes[4] (UInt8) 109
-                      bytes[5] (UInt8) 85
-                      bytes[6] (UInt8) 233
-                      bytes[7] (UInt8) 74
-                      bytes[8] (UInt8) 38
-                      bytes[9] (UInt8) 243
-                      bytes[10] (UInt8) 91
-                      bytes[11] (UInt8) 235
-                      bytes[12] (UInt8) 156
-                      bytes[13] (UInt8) 137
-                      bytes[14] (UInt8) 87
-                      bytes[15] (UInt8) 36
+                    data[0] (Hash128) 8d4f83696d55e94a26f35beb9c895724
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -7342,23 +7246,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 14
-                      bytes[1] (UInt8) 101
-                      bytes[2] (UInt8) 252
-                      bytes[3] (UInt8) 148
-                      bytes[4] (UInt8) 131
-                      bytes[5] (UInt8) 243
-                      bytes[6] (UInt8) 140
-                      bytes[7] (UInt8) 100
-                      bytes[8] (UInt8) 40
-                      bytes[9] (UInt8) 22
-                      bytes[10] (UInt8) 26
-                      bytes[11] (UInt8) 74
-                      bytes[12] (UInt8) 22
-                      bytes[13] (UInt8) 224
-                      bytes[14] (UInt8) 57
-                      bytes[15] (UInt8) 153
+                    data[0] (Hash128) 0e65fc9483f38c6428161a4a16e03999
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -9429,23 +9317,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 15
-    bytes[1] (UInt8) 113
-    bytes[2] (UInt8) 115
-    bytes[3] (UInt8) 62
-    bytes[4] (UInt8) 27
-    bytes[5] (UInt8) 101
-    bytes[6] (UInt8) 58
-    bytes[7] (UInt8) 215
-    bytes[8] (UInt8) 158
-    bytes[9] (UInt8) 42
-    bytes[10] (UInt8) 252
-    bytes[11] (UInt8) 193
-    bytes[12] (UInt8) 221
-    bytes[13] (UInt8) 6
-    bytes[14] (UInt8) 197
-    bytes[15] (UInt8) 236
+  m_PropertiesHash (Hash128) 0f71733e1b653ad79e2afcc1dd06c5ec
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp.dll
@@ -9869,23 +9741,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 235
-                      bytes[1] (UInt8) 25
-                      bytes[2] (UInt8) 11
-                      bytes[3] (UInt8) 91
-                      bytes[4] (UInt8) 28
-                      bytes[5] (UInt8) 211
-                      bytes[6] (UInt8) 44
-                      bytes[7] (UInt8) 160
-                      bytes[8] (UInt8) 219
-                      bytes[9] (UInt8) 152
-                      bytes[10] (UInt8) 220
-                      bytes[11] (UInt8) 150
-                      bytes[12] (UInt8) 74
-                      bytes[13] (UInt8) 194
-                      bytes[14] (UInt8) 88
-                      bytes[15] (UInt8) 79
+                    data[0] (Hash128) eb190b5b1cd32ca0db98dc964ac2584f
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -11390,23 +11246,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 139
-                      bytes[1] (UInt8) 77
-                      bytes[2] (UInt8) 71
-                      bytes[3] (UInt8) 86
-                      bytes[4] (UInt8) 41
-                      bytes[5] (UInt8) 32
-                      bytes[6] (UInt8) 253
-                      bytes[7] (UInt8) 37
-                      bytes[8] (UInt8) 211
-                      bytes[9] (UInt8) 99
-                      bytes[10] (UInt8) 200
-                      bytes[11] (UInt8) 250
-                      bytes[12] (UInt8) 149
-                      bytes[13] (UInt8) 193
-                      bytes[14] (UInt8) 153
-                      bytes[15] (UInt8) 81
+                    data[0] (Hash128) 8b4d47562920fd25d363c8fa95c19951
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -13733,23 +13573,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 200
-                      bytes[1] (UInt8) 200
-                      bytes[2] (UInt8) 225
-                      bytes[3] (UInt8) 217
-                      bytes[4] (UInt8) 138
-                      bytes[5] (UInt8) 20
-                      bytes[6] (UInt8) 157
-                      bytes[7] (UInt8) 43
-                      bytes[8] (UInt8) 89
-                      bytes[9] (UInt8) 242
-                      bytes[10] (UInt8) 152
-                      bytes[11] (UInt8) 123
-                      bytes[12] (UInt8) 74
-                      bytes[13] (UInt8) 77
-                      bytes[14] (UInt8) 38
-                      bytes[15] (UInt8) 12
+                    data[0] (Hash128) c8c8e1d98a149d2b59f2987b4a4d260c
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -14502,23 +14326,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 7
-                      bytes[1] (UInt8) 21
-                      bytes[2] (UInt8) 181
-                      bytes[3] (UInt8) 160
-                      bytes[4] (UInt8) 14
-                      bytes[5] (UInt8) 45
-                      bytes[6] (UInt8) 197
-                      bytes[7] (UInt8) 232
-                      bytes[8] (UInt8) 73
-                      bytes[9] (UInt8) 95
-                      bytes[10] (UInt8) 84
-                      bytes[11] (UInt8) 149
-                      bytes[12] (UInt8) 242
-                      bytes[13] (UInt8) 141
-                      bytes[14] (UInt8) 3
-                      bytes[15] (UInt8) 31
+                    data[0] (Hash128) 0715b5a00e2dc5e8495f5495f28d031f
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -15682,23 +15490,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 208
-                      bytes[1] (UInt8) 149
-                      bytes[2] (UInt8) 90
-                      bytes[3] (UInt8) 115
-                      bytes[4] (UInt8) 155
-                      bytes[5] (UInt8) 122
-                      bytes[6] (UInt8) 176
-                      bytes[7] (UInt8) 183
-                      bytes[8] (UInt8) 115
-                      bytes[9] (UInt8) 15
-                      bytes[10] (UInt8) 218
-                      bytes[11] (UInt8) 225
-                      bytes[12] (UInt8) 200
-                      bytes[13] (UInt8) 86
-                      bytes[14] (UInt8) 100
-                      bytes[15] (UInt8) 217
+                    data[0] (Hash128) d0955a739b7ab0b7730fdae1c85664d9
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -17194,23 +16986,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 195
-                      bytes[1] (UInt8) 39
-                      bytes[2] (UInt8) 187
-                      bytes[3] (UInt8) 179
-                      bytes[4] (UInt8) 204
-                      bytes[5] (UInt8) 235
-                      bytes[6] (UInt8) 191
-                      bytes[7] (UInt8) 157
-                      bytes[8] (UInt8) 23
-                      bytes[9] (UInt8) 112
-                      bytes[10] (UInt8) 86
-                      bytes[11] (UInt8) 119
-                      bytes[12] (UInt8) 209
-                      bytes[13] (UInt8) 199
-                      bytes[14] (UInt8) 142
-                      bytes[15] (UInt8) 53
+                    data[0] (Hash128) c327bbb3ccebbf9d17705677d1c78e35
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -19108,23 +18884,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 127
-                      bytes[1] (UInt8) 26
-                      bytes[2] (UInt8) 235
-                      bytes[3] (UInt8) 127
-                      bytes[4] (UInt8) 198
-                      bytes[5] (UInt8) 158
-                      bytes[6] (UInt8) 191
-                      bytes[7] (UInt8) 184
-                      bytes[8] (UInt8) 158
-                      bytes[9] (UInt8) 85
-                      bytes[10] (UInt8) 183
-                      bytes[11] (UInt8) 229
-                      bytes[12] (UInt8) 61
-                      bytes[13] (UInt8) 142
-                      bytes[14] (UInt8) 38
-                      bytes[15] (UInt8) 210
+                    data[0] (Hash128) 7f1aeb7fc69ebfb89e55b7e53d8e26d2
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14

--- a/UnityDataTool.Tests/ExpectedData/2022.1.20f1/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2022.1.20f1/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -1479,23 +1479,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 130
-                      bytes[1] (UInt8) 21
-                      bytes[2] (UInt8) 105
-                      bytes[3] (UInt8) 189
-                      bytes[4] (UInt8) 199
-                      bytes[5] (UInt8) 81
-                      bytes[6] (UInt8) 74
-                      bytes[7] (UInt8) 30
-                      bytes[8] (UInt8) 158
-                      bytes[9] (UInt8) 205
-                      bytes[10] (UInt8) 17
-                      bytes[11] (UInt8) 69
-                      bytes[12] (UInt8) 153
-                      bytes[13] (UInt8) 30
-                      bytes[14] (UInt8) 31
-                      bytes[15] (UInt8) 176
+                    data[0] (Hash128) 821569bdc7514a1e9ecd1145991e1fb0
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -2125,23 +2109,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 70
-                      bytes[1] (UInt8) 216
-                      bytes[2] (UInt8) 229
-                      bytes[3] (UInt8) 146
-                      bytes[4] (UInt8) 169
-                      bytes[5] (UInt8) 238
-                      bytes[6] (UInt8) 88
-                      bytes[7] (UInt8) 221
-                      bytes[8] (UInt8) 65
-                      bytes[9] (UInt8) 22
-                      bytes[10] (UInt8) 152
-                      bytes[11] (UInt8) 126
-                      bytes[12] (UInt8) 255
-                      bytes[13] (UInt8) 131
-                      bytes[14] (UInt8) 56
-                      bytes[15] (UInt8) 82
+                    data[0] (Hash128) 46d8e592a9ee58dd4116987eff833852
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -2860,23 +2828,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 2
-                      bytes[1] (UInt8) 69
-                      bytes[2] (UInt8) 211
-                      bytes[3] (UInt8) 212
-                      bytes[4] (UInt8) 78
-                      bytes[5] (UInt8) 179
-                      bytes[6] (UInt8) 34
-                      bytes[7] (UInt8) 158
-                      bytes[8] (UInt8) 103
-                      bytes[9] (UInt8) 198
-                      bytes[10] (UInt8) 160
-                      bytes[11] (UInt8) 247
-                      bytes[12] (UInt8) 30
-                      bytes[13] (UInt8) 117
-                      bytes[14] (UInt8) 212
-                      bytes[15] (UInt8) 100
+                    data[0] (Hash128) 0245d3d44eb3229e67c6a0f71e75d464
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -3470,23 +3422,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 234
-                      bytes[1] (UInt8) 89
-                      bytes[2] (UInt8) 0
-                      bytes[3] (UInt8) 252
-                      bytes[4] (UInt8) 248
-                      bytes[5] (UInt8) 36
-                      bytes[6] (UInt8) 182
-                      bytes[7] (UInt8) 39
-                      bytes[8] (UInt8) 12
-                      bytes[9] (UInt8) 97
-                      bytes[10] (UInt8) 86
-                      bytes[11] (UInt8) 90
-                      bytes[12] (UInt8) 239
-                      bytes[13] (UInt8) 175
-                      bytes[14] (UInt8) 219
-                      bytes[15] (UInt8) 140
+                    data[0] (Hash128) ea5900fcf824b6270c61565aefafdb8c
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -4087,23 +4023,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 108
-                      bytes[1] (UInt8) 85
-                      bytes[2] (UInt8) 40
-                      bytes[3] (UInt8) 239
-                      bytes[4] (UInt8) 29
-                      bytes[5] (UInt8) 184
-                      bytes[6] (UInt8) 194
-                      bytes[7] (UInt8) 55
-                      bytes[8] (UInt8) 242
-                      bytes[9] (UInt8) 68
-                      bytes[10] (UInt8) 254
-                      bytes[11] (UInt8) 37
-                      bytes[12] (UInt8) 3
-                      bytes[13] (UInt8) 128
-                      bytes[14] (UInt8) 105
-                      bytes[15] (UInt8) 100
+                    data[0] (Hash128) 6c5528ef1db8c237f244fe2503806964
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -4733,23 +4653,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 164
-                      bytes[1] (UInt8) 14
-                      bytes[2] (UInt8) 116
-                      bytes[3] (UInt8) 30
-                      bytes[4] (UInt8) 67
-                      bytes[5] (UInt8) 31
-                      bytes[6] (UInt8) 223
-                      bytes[7] (UInt8) 105
-                      bytes[8] (UInt8) 48
-                      bytes[9] (UInt8) 112
-                      bytes[10] (UInt8) 197
-                      bytes[11] (UInt8) 194
-                      bytes[12] (UInt8) 242
-                      bytes[13] (UInt8) 152
-                      bytes[14] (UInt8) 23
-                      bytes[15] (UInt8) 149
+                    data[0] (Hash128) a40e741e431fdf693070c5c2f2981795
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -5426,23 +5330,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 219
-                      bytes[1] (UInt8) 11
-                      bytes[2] (UInt8) 248
-                      bytes[3] (UInt8) 138
-                      bytes[4] (UInt8) 211
-                      bytes[5] (UInt8) 221
-                      bytes[6] (UInt8) 82
-                      bytes[7] (UInt8) 98
-                      bytes[8] (UInt8) 177
-                      bytes[9] (UInt8) 128
-                      bytes[10] (UInt8) 197
-                      bytes[11] (UInt8) 221
-                      bytes[12] (UInt8) 213
-                      bytes[13] (UInt8) 37
-                      bytes[14] (UInt8) 104
-                      bytes[15] (UInt8) 85
+                    data[0] (Hash128) db0bf88ad3dd5262b180c5ddd5256855
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -7484,23 +7372,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 76
-    bytes[1] (UInt8) 226
-    bytes[2] (UInt8) 250
-    bytes[3] (UInt8) 179
-    bytes[4] (UInt8) 193
-    bytes[5] (UInt8) 50
-    bytes[6] (UInt8) 194
-    bytes[7] (UInt8) 103
-    bytes[8] (UInt8) 19
-    bytes[9] (UInt8) 229
-    bytes[10] (UInt8) 205
-    bytes[11] (UInt8) 63
-    bytes[12] (UInt8) 88
-    bytes[13] (UInt8) 242
-    bytes[14] (UInt8) 226
-    bytes[15] (UInt8) 41
+  m_PropertiesHash (Hash128) 4ce2fab3c132c26713e5cd3f58f2e229
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp.dll
@@ -7924,23 +7796,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 22
-                      bytes[1] (UInt8) 241
-                      bytes[2] (UInt8) 147
-                      bytes[3] (UInt8) 228
-                      bytes[4] (UInt8) 107
-                      bytes[5] (UInt8) 119
-                      bytes[6] (UInt8) 120
-                      bytes[7] (UInt8) 105
-                      bytes[8] (UInt8) 199
-                      bytes[9] (UInt8) 91
-                      bytes[10] (UInt8) 26
-                      bytes[11] (UInt8) 58
-                      bytes[12] (UInt8) 200
-                      bytes[13] (UInt8) 19
-                      bytes[14] (UInt8) 4
-                      bytes[15] (UInt8) 63
+                    data[0] (Hash128) 16f193e46b777869c75b1a3ac813043f
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -8682,23 +8538,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 99
-                      bytes[1] (UInt8) 167
-                      bytes[2] (UInt8) 249
-                      bytes[3] (UInt8) 161
-                      bytes[4] (UInt8) 249
-                      bytes[5] (UInt8) 170
-                      bytes[6] (UInt8) 14
-                      bytes[7] (UInt8) 200
-                      bytes[8] (UInt8) 208
-                      bytes[9] (UInt8) 233
-                      bytes[10] (UInt8) 175
-                      bytes[11] (UInt8) 111
-                      bytes[12] (UInt8) 161
-                      bytes[13] (UInt8) 248
-                      bytes[14] (UInt8) 87
-                      bytes[15] (UInt8) 188
+                    data[0] (Hash128) 63a7f9a1f9aa0ec8d0e9af6fa1f857bc
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -9599,23 +9439,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 64
-                      bytes[1] (UInt8) 221
-                      bytes[2] (UInt8) 152
-                      bytes[3] (UInt8) 90
-                      bytes[4] (UInt8) 181
-                      bytes[5] (UInt8) 177
-                      bytes[6] (UInt8) 212
-                      bytes[7] (UInt8) 128
-                      bytes[8] (UInt8) 155
-                      bytes[9] (UInt8) 180
-                      bytes[10] (UInt8) 102
-                      bytes[11] (UInt8) 223
-                      bytes[12] (UInt8) 41
-                      bytes[13] (UInt8) 154
-                      bytes[14] (UInt8) 157
-                      bytes[15] (UInt8) 138
+                    data[0] (Hash128) 40dd985ab5b1d4809bb466df299a9d8a
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -10237,23 +10061,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 78
-                      bytes[1] (UInt8) 57
-                      bytes[2] (UInt8) 184
-                      bytes[3] (UInt8) 47
-                      bytes[4] (UInt8) 91
-                      bytes[5] (UInt8) 190
-                      bytes[6] (UInt8) 62
-                      bytes[7] (UInt8) 238
-                      bytes[8] (UInt8) 96
-                      bytes[9] (UInt8) 0
-                      bytes[10] (UInt8) 18
-                      bytes[11] (UInt8) 15
-                      bytes[12] (UInt8) 146
-                      bytes[13] (UInt8) 165
-                      bytes[14] (UInt8) 137
-                      bytes[15] (UInt8) 11
+                    data[0] (Hash128) 4e39b82f5bbe3eee6000120f92a5890b
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -10938,23 +10746,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 222
-                      bytes[1] (UInt8) 207
-                      bytes[2] (UInt8) 12
-                      bytes[3] (UInt8) 99
-                      bytes[4] (UInt8) 14
-                      bytes[5] (UInt8) 58
-                      bytes[6] (UInt8) 206
-                      bytes[7] (UInt8) 189
-                      bytes[8] (UInt8) 129
-                      bytes[9] (UInt8) 171
-                      bytes[10] (UInt8) 51
-                      bytes[11] (UInt8) 106
-                      bytes[12] (UInt8) 253
-                      bytes[13] (UInt8) 53
-                      bytes[14] (UInt8) 239
-                      bytes[15] (UInt8) 249
+                    data[0] (Hash128) decf0c630e3acebd81ab336afd35eff9
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -11687,23 +11479,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 189
-                      bytes[1] (UInt8) 92
-                      bytes[2] (UInt8) 76
-                      bytes[3] (UInt8) 61
-                      bytes[4] (UInt8) 242
-                      bytes[5] (UInt8) 228
-                      bytes[6] (UInt8) 250
-                      bytes[7] (UInt8) 204
-                      bytes[8] (UInt8) 222
-                      bytes[9] (UInt8) 214
-                      bytes[10] (UInt8) 62
-                      bytes[11] (UInt8) 115
-                      bytes[12] (UInt8) 18
-                      bytes[13] (UInt8) 118
-                      bytes[14] (UInt8) 132
-                      bytes[15] (UInt8) 56
+                    data[0] (Hash128) bd5c4c3df2e4faccded63e7312768438
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -12520,23 +12296,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 34
-                      bytes[1] (UInt8) 44
-                      bytes[2] (UInt8) 31
-                      bytes[3] (UInt8) 47
-                      bytes[4] (UInt8) 64
-                      bytes[5] (UInt8) 81
-                      bytes[6] (UInt8) 179
-                      bytes[7] (UInt8) 173
-                      bytes[8] (UInt8) 119
-                      bytes[9] (UInt8) 226
-                      bytes[10] (UInt8) 242
-                      bytes[11] (UInt8) 88
-                      bytes[12] (UInt8) 209
-                      bytes[13] (UInt8) 229
-                      bytes[14] (UInt8) 254
-                      bytes[15] (UInt8) 243
+                    data[0] (Hash128) 222c1f2f4051b3ad77e2f258d1e5fef3
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14

--- a/UnityDataTool.Tests/ExpectedData/2022.1.20f1/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2022.1.20f1/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -1479,23 +1479,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 130
-                      bytes[1] (UInt8) 21
-                      bytes[2] (UInt8) 105
-                      bytes[3] (UInt8) 189
-                      bytes[4] (UInt8) 199
-                      bytes[5] (UInt8) 81
-                      bytes[6] (UInt8) 74
-                      bytes[7] (UInt8) 30
-                      bytes[8] (UInt8) 158
-                      bytes[9] (UInt8) 205
-                      bytes[10] (UInt8) 17
-                      bytes[11] (UInt8) 69
-                      bytes[12] (UInt8) 153
-                      bytes[13] (UInt8) 30
-                      bytes[14] (UInt8) 31
-                      bytes[15] (UInt8) 176
+                    data[0] (Hash128) 821569bdc7514a1e9ecd1145991e1fb0
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -2125,23 +2109,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 70
-                      bytes[1] (UInt8) 216
-                      bytes[2] (UInt8) 229
-                      bytes[3] (UInt8) 146
-                      bytes[4] (UInt8) 169
-                      bytes[5] (UInt8) 238
-                      bytes[6] (UInt8) 88
-                      bytes[7] (UInt8) 221
-                      bytes[8] (UInt8) 65
-                      bytes[9] (UInt8) 22
-                      bytes[10] (UInt8) 152
-                      bytes[11] (UInt8) 126
-                      bytes[12] (UInt8) 255
-                      bytes[13] (UInt8) 131
-                      bytes[14] (UInt8) 56
-                      bytes[15] (UInt8) 82
+                    data[0] (Hash128) 46d8e592a9ee58dd4116987eff833852
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -2860,23 +2828,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 2
-                      bytes[1] (UInt8) 69
-                      bytes[2] (UInt8) 211
-                      bytes[3] (UInt8) 212
-                      bytes[4] (UInt8) 78
-                      bytes[5] (UInt8) 179
-                      bytes[6] (UInt8) 34
-                      bytes[7] (UInt8) 158
-                      bytes[8] (UInt8) 103
-                      bytes[9] (UInt8) 198
-                      bytes[10] (UInt8) 160
-                      bytes[11] (UInt8) 247
-                      bytes[12] (UInt8) 30
-                      bytes[13] (UInt8) 117
-                      bytes[14] (UInt8) 212
-                      bytes[15] (UInt8) 100
+                    data[0] (Hash128) 0245d3d44eb3229e67c6a0f71e75d464
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -3470,23 +3422,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 234
-                      bytes[1] (UInt8) 89
-                      bytes[2] (UInt8) 0
-                      bytes[3] (UInt8) 252
-                      bytes[4] (UInt8) 248
-                      bytes[5] (UInt8) 36
-                      bytes[6] (UInt8) 182
-                      bytes[7] (UInt8) 39
-                      bytes[8] (UInt8) 12
-                      bytes[9] (UInt8) 97
-                      bytes[10] (UInt8) 86
-                      bytes[11] (UInt8) 90
-                      bytes[12] (UInt8) 239
-                      bytes[13] (UInt8) 175
-                      bytes[14] (UInt8) 219
-                      bytes[15] (UInt8) 140
+                    data[0] (Hash128) ea5900fcf824b6270c61565aefafdb8c
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -4087,23 +4023,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 108
-                      bytes[1] (UInt8) 85
-                      bytes[2] (UInt8) 40
-                      bytes[3] (UInt8) 239
-                      bytes[4] (UInt8) 29
-                      bytes[5] (UInt8) 184
-                      bytes[6] (UInt8) 194
-                      bytes[7] (UInt8) 55
-                      bytes[8] (UInt8) 242
-                      bytes[9] (UInt8) 68
-                      bytes[10] (UInt8) 254
-                      bytes[11] (UInt8) 37
-                      bytes[12] (UInt8) 3
-                      bytes[13] (UInt8) 128
-                      bytes[14] (UInt8) 105
-                      bytes[15] (UInt8) 100
+                    data[0] (Hash128) 6c5528ef1db8c237f244fe2503806964
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -4733,23 +4653,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 164
-                      bytes[1] (UInt8) 14
-                      bytes[2] (UInt8) 116
-                      bytes[3] (UInt8) 30
-                      bytes[4] (UInt8) 67
-                      bytes[5] (UInt8) 31
-                      bytes[6] (UInt8) 223
-                      bytes[7] (UInt8) 105
-                      bytes[8] (UInt8) 48
-                      bytes[9] (UInt8) 112
-                      bytes[10] (UInt8) 197
-                      bytes[11] (UInt8) 194
-                      bytes[12] (UInt8) 242
-                      bytes[13] (UInt8) 152
-                      bytes[14] (UInt8) 23
-                      bytes[15] (UInt8) 149
+                    data[0] (Hash128) a40e741e431fdf693070c5c2f2981795
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -5426,23 +5330,7 @@ ID: -4850512016903265157 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 219
-                      bytes[1] (UInt8) 11
-                      bytes[2] (UInt8) 248
-                      bytes[3] (UInt8) 138
-                      bytes[4] (UInt8) 211
-                      bytes[5] (UInt8) 221
-                      bytes[6] (UInt8) 82
-                      bytes[7] (UInt8) 98
-                      bytes[8] (UInt8) 177
-                      bytes[9] (UInt8) 128
-                      bytes[10] (UInt8) 197
-                      bytes[11] (UInt8) 221
-                      bytes[12] (UInt8) 213
-                      bytes[13] (UInt8) 37
-                      bytes[14] (UInt8) 104
-                      bytes[15] (UInt8) 85
+                    data[0] (Hash128) db0bf88ad3dd5262b180c5ddd5256855
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -7484,23 +7372,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 76
-    bytes[1] (UInt8) 226
-    bytes[2] (UInt8) 250
-    bytes[3] (UInt8) 179
-    bytes[4] (UInt8) 193
-    bytes[5] (UInt8) 50
-    bytes[6] (UInt8) 194
-    bytes[7] (UInt8) 103
-    bytes[8] (UInt8) 19
-    bytes[9] (UInt8) 229
-    bytes[10] (UInt8) 205
-    bytes[11] (UInt8) 63
-    bytes[12] (UInt8) 88
-    bytes[13] (UInt8) 242
-    bytes[14] (UInt8) 226
-    bytes[15] (UInt8) 41
+  m_PropertiesHash (Hash128) 4ce2fab3c132c26713e5cd3f58f2e229
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp.dll
@@ -7924,23 +7796,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 22
-                      bytes[1] (UInt8) 241
-                      bytes[2] (UInt8) 147
-                      bytes[3] (UInt8) 228
-                      bytes[4] (UInt8) 107
-                      bytes[5] (UInt8) 119
-                      bytes[6] (UInt8) 120
-                      bytes[7] (UInt8) 105
-                      bytes[8] (UInt8) 199
-                      bytes[9] (UInt8) 91
-                      bytes[10] (UInt8) 26
-                      bytes[11] (UInt8) 58
-                      bytes[12] (UInt8) 200
-                      bytes[13] (UInt8) 19
-                      bytes[14] (UInt8) 4
-                      bytes[15] (UInt8) 63
+                    data[0] (Hash128) 16f193e46b777869c75b1a3ac813043f
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -8682,23 +8538,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 99
-                      bytes[1] (UInt8) 167
-                      bytes[2] (UInt8) 249
-                      bytes[3] (UInt8) 161
-                      bytes[4] (UInt8) 249
-                      bytes[5] (UInt8) 170
-                      bytes[6] (UInt8) 14
-                      bytes[7] (UInt8) 200
-                      bytes[8] (UInt8) 208
-                      bytes[9] (UInt8) 233
-                      bytes[10] (UInt8) 175
-                      bytes[11] (UInt8) 111
-                      bytes[12] (UInt8) 161
-                      bytes[13] (UInt8) 248
-                      bytes[14] (UInt8) 87
-                      bytes[15] (UInt8) 188
+                    data[0] (Hash128) 63a7f9a1f9aa0ec8d0e9af6fa1f857bc
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -9599,23 +9439,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 64
-                      bytes[1] (UInt8) 221
-                      bytes[2] (UInt8) 152
-                      bytes[3] (UInt8) 90
-                      bytes[4] (UInt8) 181
-                      bytes[5] (UInt8) 177
-                      bytes[6] (UInt8) 212
-                      bytes[7] (UInt8) 128
-                      bytes[8] (UInt8) 155
-                      bytes[9] (UInt8) 180
-                      bytes[10] (UInt8) 102
-                      bytes[11] (UInt8) 223
-                      bytes[12] (UInt8) 41
-                      bytes[13] (UInt8) 154
-                      bytes[14] (UInt8) 157
-                      bytes[15] (UInt8) 138
+                    data[0] (Hash128) 40dd985ab5b1d4809bb466df299a9d8a
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -10237,23 +10061,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[3] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 78
-                      bytes[1] (UInt8) 57
-                      bytes[2] (UInt8) 184
-                      bytes[3] (UInt8) 47
-                      bytes[4] (UInt8) 91
-                      bytes[5] (UInt8) 190
-                      bytes[6] (UInt8) 62
-                      bytes[7] (UInt8) 238
-                      bytes[8] (UInt8) 96
-                      bytes[9] (UInt8) 0
-                      bytes[10] (UInt8) 18
-                      bytes[11] (UInt8) 15
-                      bytes[12] (UInt8) 146
-                      bytes[13] (UInt8) 165
-                      bytes[14] (UInt8) 137
-                      bytes[15] (UInt8) 11
+                    data[0] (Hash128) 4e39b82f5bbe3eee6000120f92a5890b
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -10938,23 +10746,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[0] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 222
-                      bytes[1] (UInt8) 207
-                      bytes[2] (UInt8) 12
-                      bytes[3] (UInt8) 99
-                      bytes[4] (UInt8) 14
-                      bytes[5] (UInt8) 58
-                      bytes[6] (UInt8) 206
-                      bytes[7] (UInt8) 189
-                      bytes[8] (UInt8) 129
-                      bytes[9] (UInt8) 171
-                      bytes[10] (UInt8) 51
-                      bytes[11] (UInt8) 106
-                      bytes[12] (UInt8) 253
-                      bytes[13] (UInt8) 53
-                      bytes[14] (UInt8) 239
-                      bytes[15] (UInt8) 249
+                    data[0] (Hash128) decf0c630e3acebd81ab336afd35eff9
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -11687,23 +11479,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[1] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 189
-                      bytes[1] (UInt8) 92
-                      bytes[2] (UInt8) 76
-                      bytes[3] (UInt8) 61
-                      bytes[4] (UInt8) 242
-                      bytes[5] (UInt8) 228
-                      bytes[6] (UInt8) 250
-                      bytes[7] (UInt8) 204
-                      bytes[8] (UInt8) 222
-                      bytes[9] (UInt8) 214
-                      bytes[10] (UInt8) 62
-                      bytes[11] (UInt8) 115
-                      bytes[12] (UInt8) 18
-                      bytes[13] (UInt8) 118
-                      bytes[14] (UInt8) 132
-                      bytes[15] (UInt8) 56
+                    data[0] (Hash128) bd5c4c3df2e4faccded63e7312768438
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14
@@ -12520,23 +12296,7 @@ ID: -4067819952531011990 (ClassID: 48) Shader
               data[2] (SerializedPass)
                 m_EditorDataHash (vector)
                   Array<Hash128>[1]
-                    data[0] (Hash128)
-                      bytes[0] (UInt8) 34
-                      bytes[1] (UInt8) 44
-                      bytes[2] (UInt8) 31
-                      bytes[3] (UInt8) 47
-                      bytes[4] (UInt8) 64
-                      bytes[5] (UInt8) 81
-                      bytes[6] (UInt8) 179
-                      bytes[7] (UInt8) 173
-                      bytes[8] (UInt8) 119
-                      bytes[9] (UInt8) 226
-                      bytes[10] (UInt8) 242
-                      bytes[11] (UInt8) 88
-                      bytes[12] (UInt8) 209
-                      bytes[13] (UInt8) 229
-                      bytes[14] (UInt8) 254
-                      bytes[15] (UInt8) 243
+                    data[0] (Hash128) 222c1f2f4051b3ad77e2f258d1e5fef3
                 m_Platforms (vector)
                   Array<UInt8>[1]
                     14

--- a/UnityDataTool.Tests/ExpectedData/2023.1.0a16/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2023.1.0a16/dump-s/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -7415,23 +7415,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 76
-    bytes[1] (UInt8) 226
-    bytes[2] (UInt8) 250
-    bytes[3] (UInt8) 179
-    bytes[4] (UInt8) 193
-    bytes[5] (UInt8) 50
-    bytes[6] (UInt8) 194
-    bytes[7] (UInt8) 103
-    bytes[8] (UInt8) 19
-    bytes[9] (UInt8) 229
-    bytes[10] (UInt8) 205
-    bytes[11] (UInt8) 63
-    bytes[12] (UInt8) 88
-    bytes[13] (UInt8) 242
-    bytes[14] (UInt8) 226
-    bytes[15] (UInt8) 41
+  m_PropertiesHash (Hash128) 4ce2fab3c132c26713e5cd3f58f2e229
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp

--- a/UnityDataTool.Tests/ExpectedData/2023.1.0a16/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
+++ b/UnityDataTool.Tests/ExpectedData/2023.1.0a16/dump/CAB-5d40f7cad7c871cf2ad2af19ac542994.txt
@@ -7415,23 +7415,7 @@ ID: -4365321507395843767 (ClassID: 33) MeshFilter
 ID: -4339217461983190205 (ClassID: 115) MonoScript
   m_Name (string) SerializeReferencePolymorphismExample
   m_ExecutionOrder (int) 0
-  m_PropertiesHash (Hash128)
-    bytes[0] (UInt8) 76
-    bytes[1] (UInt8) 226
-    bytes[2] (UInt8) 250
-    bytes[3] (UInt8) 179
-    bytes[4] (UInt8) 193
-    bytes[5] (UInt8) 50
-    bytes[6] (UInt8) 194
-    bytes[7] (UInt8) 103
-    bytes[8] (UInt8) 19
-    bytes[9] (UInt8) 229
-    bytes[10] (UInt8) 205
-    bytes[11] (UInt8) 63
-    bytes[12] (UInt8) 88
-    bytes[13] (UInt8) 242
-    bytes[14] (UInt8) 226
-    bytes[15] (UInt8) 41
+  m_PropertiesHash (Hash128) 4ce2fab3c132c26713e5cd3f58f2e229
   m_ClassName (string) SerializeReferencePolymorphismExample
   m_Namespace (string) 
   m_AssemblyName (string) Assembly-CSharp


### PR DESCRIPTION
## Summary

Fixes #65.

The `dump` command printed `GUID` and `Hash128` fields as their raw serialized representation (4 uint32s / 16 bytes), which is hard to read and impossible to correlate with asset GUIDs or hash strings seen elsewhere. They are now printed as a single 32-character hex string matching Unity's own `GUIDToString` / `Hash128.ToString()` formats, e.g.:

```
sourceAssetGUID (GUID) 162c015549f8733449ac70ae78ad3aa5
buildManifestHash (Hash128) baff06b928d147276f2245dd3b19216a
```

## Changes

- `TextDumperTool`: new `TryReadCompoundValue` step in `RecursiveDump`, alongside the existing `string` special case. It matches compound types by type name plus expected TypeTree layout (falling back to the generic field-by-field dump if the layout doesn't match), and reuses `GuidHelper.FormatUnityGuid` / `FormatUnityHash128` from UnityBinaryFormat. Adding future friendly-printed compound types is a matter of adding a case to its switch.
- `DumpTests`: new test dumping the LeadingEdge ContentDirectory build report, asserting known GUID and Hash128 values. The expected strings are independently verifiable: `buildSessionGUID` matches the build report's filename and the scene's `sourceAssetGUID` matches `Scene1.unity.meta` in the LeadingEdge project.
- Regenerated the per-Unity-version expected dump snapshots in `UnityDataTool.Tests/ExpectedData` (only GUID/Hash128 lines changed) and updated the `analyze-examples.md` example that showed the old `m_PropertiesHash` output.

## Testing

`dotnet test -c Release` — full suite green (762 passed, 10 skipped, 0 failed).

Manually verified the new output on the checked-in build reports, ContentDirectory `.cf` files, and Player data; all GUID/Hash128 fields now print as hex strings and cross-check against `.meta` files and the build-report filename.
