### PR TITLE
[#31] Add --hexfloat option to dump bit-exact float representations

### DIFF
--- a/Documentation/command-dump.md
+++ b/Documentation/command-dump.md
@@ -15,6 +15,7 @@ UnityDataTool dump <path> [options]
 | `--stdout` | Write the dump to stdout (status and errors go to stderr). Mutually exclusive with `-o`. | `false` |
 | `-f, --output-format <format>` | Output format | `text` |
 | `-a, --show-large-arrays` | Dump the full content of large arrays of basic data types, instead of summarizing them with a hash | `false` |
+| `-x, --hexfloat` | Print the bit-exact hexadecimal representation after each float and double value | `false` |
 | `-i, --objectid <id>` | Only dump object with this ID | All objects |
 | `-t, --type <type>` | Filter by object type (ClassID number or type name) | All objects |
 | `-d, --typetree-data <file>` | Load an external TypeTree data file before processing (Unity 6.5+) | — |
@@ -39,6 +40,15 @@ UnityDataTool dump /path/to/file -i 1234567890
 Dump the full content of large arrays (e.g. mesh or texture data):
 ```bash
 UnityDataTool dump /path/to/file -a
+```
+
+Include the bit-exact hexadecimal representation of float and double values, useful for seeing tiny differences that get lost when converting to decimal (similar to the `-hexfloat` option of Unity's `binary2text` tool):
+```bash
+UnityDataTool dump /path/to/file -x
+```
+```
+floatValue (float) 3.1415927(0x40490fdb)
+doubleValue (double) 2.718281828459045(0x4005bf0a8b145769)
 ```
 
 Dump only MonoBehaviour objects by type name:

--- a/TextDumper/TextDumperTool.cs
+++ b/TextDumper/TextDumperTool.cs
@@ -34,6 +34,7 @@ public class TextDumperTool
         public string Path { get; init; }
         public string OutputPath { get; init; }
         public bool ShowLargeArrays { get; init; }
+        public bool HexFloat { get; init; }
         public long ObjectId { get; init; }
         public string TypeFilter { get; init; }
         public bool ToStdout { get; init; }
@@ -382,11 +383,11 @@ public class TextDumperTool
                     var array = ReadBasicTypeArray(dataNode, offset, arraySize);
                     offset += dataNode.Size * arraySize;
 
-                    m_StringBuilder.Append(array.GetValue(0));
+                    m_StringBuilder.Append(FormatArrayElement(array.GetValue(0)));
                     for (int i = 1; i < arraySize; ++i)
                     {
                         m_StringBuilder.Append(", ");
-                        m_StringBuilder.Append(array.GetValue(i));
+                        m_StringBuilder.Append(FormatArrayElement(array.GetValue(i)));
                     }
                 }
 
@@ -608,10 +609,10 @@ public class TextDumperTool
                 return m_Reader.ReadUInt32(offset).ToString();
 
             case TypeCode.Single:
-                return m_Reader.ReadFloat(offset).ToString();
+                return FormatFloat(m_Reader.ReadFloat(offset));
 
             case TypeCode.Double:
-                return m_Reader.ReadDouble(offset).ToString();
+                return FormatDouble(m_Reader.ReadDouble(offset));
 
             case TypeCode.Int16:
                 return m_Reader.ReadInt16(offset).ToString();
@@ -639,6 +640,22 @@ public class TextDumperTool
                 throw new Exception($"Can't get value of {node.Type} type");
         }
     }
+
+    // With the HexFloat option, floating point values are followed by their bit-exact hexadecimal
+    // representation (like binary2text -hexfloat), because tiny differences between two values can
+    // be lost when they are converted to decimal.
+    string FormatFloat(float value) =>
+        m_Options.HexFloat ? $"{value}(0x{BitConverter.SingleToUInt32Bits(value):x8})" : value.ToString();
+
+    string FormatDouble(double value) =>
+        m_Options.HexFloat ? $"{value}(0x{BitConverter.DoubleToUInt64Bits(value):x16})" : value.ToString();
+
+    string FormatArrayElement(object value) => value switch
+    {
+        float f => FormatFloat(f),
+        double d => FormatDouble(d),
+        _ => value.ToString(),
+    };
 
     Array ReadBasicTypeArray(TypeTreeNode node, long offset, int arraySize)
     {

--- a/TextDumper/TextDumperTool.cs
+++ b/TextDumper/TextDumperTool.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Text;
 using UnityDataTools.BinaryFormat;
@@ -643,12 +644,17 @@ public class TextDumperTool
 
     // With the HexFloat option, floating point values are followed by their bit-exact hexadecimal
     // representation (like binary2text -hexfloat), because tiny differences between two values can
-    // be lost when they are converted to decimal.
+    // be lost when they are converted to decimal. The decimal part always uses the invariant
+    // culture so that dumps are identical (and diffable) across locales.
     string FormatFloat(float value) =>
-        m_Options.HexFloat ? $"{value}(0x{BitConverter.SingleToUInt32Bits(value):x8})" : value.ToString();
+        m_Options.HexFloat
+            ? string.Create(CultureInfo.InvariantCulture, $"{value}(0x{BitConverter.SingleToUInt32Bits(value):x8})")
+            : value.ToString(CultureInfo.InvariantCulture);
 
     string FormatDouble(double value) =>
-        m_Options.HexFloat ? $"{value}(0x{BitConverter.DoubleToUInt64Bits(value):x16})" : value.ToString();
+        m_Options.HexFloat
+            ? string.Create(CultureInfo.InvariantCulture, $"{value}(0x{BitConverter.DoubleToUInt64Bits(value):x16})")
+            : value.ToString(CultureInfo.InvariantCulture);
 
     string FormatArrayElement(object value) => value switch
     {

--- a/UnityDataTool.Tests/DumpTests.cs
+++ b/UnityDataTool.Tests/DumpTests.cs
@@ -314,6 +314,30 @@ public class DumpTests
         Assert.That(output, Does.Not.Contain("293, 294, 295, 296,"));
     }
 
+    // The expected bit patterns are the well-known IEEE 754 representations of the
+    // SerializationDemo field values (also verified against python struct.pack).
+    [Test]
+    public async Task Dump_Stdout_HexFloat_PrintsBitExactRepresentation(
+        [Values("-x", "--hexfloat")] string options)
+    {
+        using var sw = new StringWriter();
+        var currentOut = Console.Out;
+        try
+        {
+            Console.SetOut(sw);
+            Assert.AreEqual(0, await Program.Main(new string[] { "dump", m_SerializationDemoBundlePath, "--stdout", "--type", "MonoBehaviour", options }));
+        }
+        finally
+        {
+            Console.SetOut(currentOut);
+        }
+
+        var output = sw.ToString();
+
+        Assert.That(output, Does.Contain("floatValue (float) 3.1415927(0x40490fdb)"));
+        Assert.That(output, Does.Contain("doubleValue (double) 2.718281828459045(0x4005bf0a8b145769)"));
+    }
+
     [Test]
     public async Task Dump_Stdout_ShowLargeArrays_PrintsFullArrayContent()
     {

--- a/UnityDataTool.Tests/DumpTests.cs
+++ b/UnityDataTool.Tests/DumpTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Globalization;
 using System.IO;
 using System.Threading.Tasks;
 using NUnit.Framework;
@@ -316,20 +317,24 @@ public class DumpTests
 
     // The expected bit patterns are the well-known IEEE 754 representations of the
     // SerializationDemo field values (also verified against python struct.pack).
+    // Runs under a comma-decimal locale to confirm the output is culture-invariant.
     [Test]
     public async Task Dump_Stdout_HexFloat_PrintsBitExactRepresentation(
         [Values("-x", "--hexfloat")] string options)
     {
         using var sw = new StringWriter();
         var currentOut = Console.Out;
+        var currentCulture = CultureInfo.CurrentCulture;
         try
         {
             Console.SetOut(sw);
+            CultureInfo.CurrentCulture = new CultureInfo("de-DE");
             Assert.AreEqual(0, await Program.Main(new string[] { "dump", m_SerializationDemoBundlePath, "--stdout", "--type", "MonoBehaviour", options }));
         }
         finally
         {
             Console.SetOut(currentOut);
+            CultureInfo.CurrentCulture = currentCulture;
         }
 
         var output = sw.ToString();

--- a/UnityDataTool/Program.cs
+++ b/UnityDataTool/Program.cs
@@ -167,6 +167,7 @@ public static class Program
         var pathArg = new Argument<FileInfo>("filename", "The path of the file to dump").ExistingOnly();
         var fOpt = new Option<TextDumperTool.DumpFormat>(aliases: new[] { "--output-format", "-f" }, description: "Output format", getDefaultValue: () => TextDumperTool.DumpFormat.Text);
         var aOpt = new Option<bool>(aliases: new[] { "--show-large-arrays", "-a" }, description: "Dump the full content of large arrays of basic data types, instead of summarizing them with a hash");
+        var xOpt = new Option<bool>(aliases: new[] { "--hexfloat", "-x" }, description: "Print the bit-exact hexadecimal representation after each float and double value, e.g. 0.25(0x3e800000)");
         // Former option, kept so that existing scripts don't break. Ignored because skipping
         // large arrays (with a hash) is now the default behavior.
         var sOpt = new Option<bool>(aliases: new[] { "--skip-large-arrays", "-s" }) { IsHidden = true };
@@ -182,6 +183,7 @@ public static class Program
             pathArg,
             fOpt,
             aOpt,
+            xOpt,
             sOpt,
             oOpt,
             objectIdOpt,
@@ -201,7 +203,7 @@ public static class Program
             }
         });
         dumpCommand.SetHandler(
-            (FileInfo fi, TextDumperTool.DumpFormat f, bool a, DirectoryInfo o, long objectId, string type, FileInfo d, bool toStdout) =>
+            (FileInfo fi, TextDumperTool.DumpFormat f, bool a, bool x, DirectoryInfo o, long objectId, string type, FileInfo d, bool toStdout) =>
             {
                 var ttResult = LoadTypeTreeDataFile(d);
                 if (ttResult != 0) return Task.FromResult(ttResult);
@@ -211,13 +213,14 @@ public static class Program
                     Path = fi.FullName,
                     OutputPath = o.FullName,
                     ShowLargeArrays = a,
+                    HexFloat = x,
                     ObjectId = objectId,
                     TypeFilter = type,
                     ToStdout = toStdout,
                 };
                 return Task.FromResult(HandleDump(options));
             },
-            pathArg, fOpt, aOpt, oOpt, objectIdOpt, typeOpt, dOpt, stdoutOpt);
+            pathArg, fOpt, aOpt, xOpt, oOpt, objectIdOpt, typeOpt, dOpt, stdoutOpt);
 
         return dumpCommand;
     }


### PR DESCRIPTION
## Summary

Fixes #31.

Tiny differences between float values get lost when they are converted to decimal, which makes them invisible when diffing two dumps. This adds the equivalent of binary2text's `-hexfloat` option: with `-x` / `--hexfloat`, every float and double value is followed by its bit-exact hexadecimal representation, in the same `value(0xhex)` format binary2text uses:

```
floatValue (float) 3.1415927(0x40490fdb)
doubleValue (double) 2.718281828459045(0x4005bf0a8b145769)
```

Note that binary2text only annotates 32-bit floats (`double` is a missing case in its output macro table); this implementation covers both float and double.

## Changes

- `TextDumperTool`: new `HexFloat` option, applied in `ReadValue` (scalars — which also covers compound types like `Vector3f`/`ColorRGBA`, whose components are float leaf nodes) and to basic-type array elements. Default output is unchanged, so the expected-data snapshots are untouched.
- CLI: new `-x` / `--hexfloat` option on the dump command.
- Tests: dump the `SerializationDemo` bundle with `-x`/`--hexfloat` and assert the known IEEE 754 bit patterns of its float and double fields (verified independently against python's `struct.pack`).
- Documentation: option table entry and an example in `command-dump.md`.

## Testing

`dotnet test -c Release` — full suite green (775 passed, 10 skipped, 0 failed).

Manually verified scalar fields, `ColorRGBA` components, and float array elements on the checked-in test data, and that default output is byte-identical to before.
