### PR TITLE
[#14] Marshal native paths as UTF-8 to support non-ASCII paths

### DIFF
--- a/UnityFileSystem.Tests/UnityFileSystemTests.cs
+++ b/UnityFileSystem.Tests/UnityFileSystemTests.cs
@@ -11,6 +11,27 @@ namespace UnityDataTools.FileSystem.Tests;
 
 #pragma warning disable NUnit2005, NUnit2006
 
+// Copies a file into a fresh temp directory whose name and file name contain non-ASCII
+// (Japanese) characters, runs the test against it, then removes the directory.
+internal static class NonAsciiPath
+{
+    public static void WithCopy(string source, string fileName, Action<string> test)
+    {
+        var dir = Path.Combine(Path.GetTempPath(), "UnityDataTools_テスト_" + Path.GetRandomFileName());
+        Directory.CreateDirectory(dir);
+        try
+        {
+            var path = Path.Combine(dir, fileName);
+            File.Copy(source, path);
+            test(path);
+        }
+        finally
+        {
+            Directory.Delete(dir, true);
+        }
+    }
+}
+
 public class ArchiveTests : AssetBundleTestFixture
 {
     public ArchiveTests(Context context) : base(context)
@@ -60,6 +81,21 @@ public class ArchiveTests : AssetBundleTestFixture
         Assert.IsNotNull(archive);
 
         archive.Dispose();
+    }
+
+    // Paths are marshalled to the native library as UTF-8, so non-ASCII paths must work.
+    [Test]
+    public void MountArchive_NonAsciiPath_ReturnsArchive()
+    {
+        var source = Path.Combine(Context.UnityDataFolder, "assetbundle");
+
+        NonAsciiPath.WithCopy(source, "アセット.bundle", path =>
+        {
+            UnityArchive archive = null;
+            Assert.DoesNotThrow(() => archive = UnityFileSystem.MountArchive(path, "archive:/"));
+            Assert.IsNotNull(archive);
+            archive.Dispose();
+        });
     }
 
     [Ignore("This test doesn't return the expected error, this condition is probably not handled correctly in Unity")]
@@ -153,6 +189,24 @@ public class UnityFileTests : AssetBundleTestFixture
         Assert.IsNotNull(file);
 
         Assert.DoesNotThrow(() => file.Dispose());
+    }
+
+    // Paths are marshalled to the native library as UTF-8, so a file at a non-ASCII path
+    // must open and read correctly (this failed when paths were marshalled as ANSI).
+    [Test]
+    public void OpenFile_NonAsciiPath_ReadsExpectedData()
+    {
+        var source = Path.Combine(Context.TestDataFolder, "TextFile.txt");
+
+        NonAsciiPath.WithCopy(source, "テキスト.txt", path =>
+        {
+            using var file = UnityFileSystem.OpenFile(path);
+            var buffer = new Byte[1000];
+            var actualSize = file.Read(1000, buffer);
+
+            Assert.AreEqual(21, actualSize);
+            Assert.AreEqual("This is my text file.", Encoding.UTF8.GetString(buffer, 0, (int)actualSize));
+        });
     }
 
     [Test]

--- a/UnityFileSystem/DllWrapper.cs
+++ b/UnityFileSystem/DllWrapper.cs
@@ -183,7 +183,7 @@ public static class DllWrapper
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "UFS_MountArchive")]
-    public static extern ReturnCode MountArchive([MarshalAs(UnmanagedType.LPStr)] string path, [MarshalAs(UnmanagedType.LPStr)] string mountPoint, out UnityArchiveHandle handle);
+    public static extern ReturnCode MountArchive([MarshalAs(UnmanagedType.LPUTF8Str)] string path, [MarshalAs(UnmanagedType.LPUTF8Str)] string mountPoint, out UnityArchiveHandle handle);
 
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
@@ -195,6 +195,10 @@ public static class DllWrapper
         EntryPoint = "UFS_GetArchiveNodeCount")]
     public static extern ReturnCode GetArchiveNodeCount(UnityArchiveHandle handle, out int count);
 
+    // Strings returned from native (here and in the other StringBuilder-based calls) come back as
+    // UTF-8 bytes but are marshalled as the system ANSI code page, so only ASCII round-trips correctly.
+    // These are internal archive/serialized-file names, which Unity keeps ASCII, so it's not an issue in
+    // practice. Input paths, by contrast, are marshalled as UTF-8 (LPUTF8Str) to support non-ASCII paths.
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "UFS_GetArchiveNode")]
@@ -203,14 +207,38 @@ public static class DllWrapper
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "UFS_CreateArchive")]
-    public static extern ReturnCode CreateArchive([MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] string[] sourceFiles,
-        [MarshalAs(UnmanagedType.LPArray, ArraySubType = UnmanagedType.LPStr)] string[] aliases, bool[] isSerializedFile, int count,
-        [MarshalAs(UnmanagedType.LPStr)] string archiveFile, CompressionType compression, out int crc);
+    private static extern ReturnCode CreateArchiveNative(IntPtr[] sourceFiles, IntPtr[] aliases, bool[] isSerializedFile, int count,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string archiveFile, CompressionType compression, out int crc);
+
+    // The native library expects UTF-8 paths. LPUTF8Str handles the scalar strings, but it
+    // can't be used as an array subtype, so the string arrays are marshalled to UTF-8 by hand.
+    public static ReturnCode CreateArchive(string[] sourceFiles, string[] aliases, bool[] isSerializedFile, int count,
+        string archiveFile, CompressionType compression, out int crc)
+    {
+        var sourcePtrs = new IntPtr[sourceFiles.Length];
+        var aliasPtrs = new IntPtr[aliases.Length];
+        try
+        {
+            for (int i = 0; i < sourceFiles.Length; ++i)
+                sourcePtrs[i] = Marshal.StringToCoTaskMemUTF8(sourceFiles[i]);
+            for (int i = 0; i < aliases.Length; ++i)
+                aliasPtrs[i] = Marshal.StringToCoTaskMemUTF8(aliases[i]);
+
+            return CreateArchiveNative(sourcePtrs, aliasPtrs, isSerializedFile, count, archiveFile, compression, out crc);
+        }
+        finally
+        {
+            foreach (var p in sourcePtrs)
+                Marshal.FreeCoTaskMem(p);
+            foreach (var p in aliasPtrs)
+                Marshal.FreeCoTaskMem(p);
+        }
+    }
 
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "UFS_OpenFile")]
-    public static extern ReturnCode OpenFile([MarshalAs(UnmanagedType.LPStr)] string path, out UnityFileHandle handle);
+    public static extern ReturnCode OpenFile([MarshalAs(UnmanagedType.LPUTF8Str)] string path, out UnityFileHandle handle);
 
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl, EntryPoint = "UFS_ReadFile")]
@@ -235,7 +263,7 @@ public static class DllWrapper
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "UFS_OpenSerializedFile")]
-    public static extern ReturnCode OpenSerializedFile([MarshalAs(UnmanagedType.LPStr)] string path, out SerializedFileHandle handle);
+    public static extern ReturnCode OpenSerializedFile([MarshalAs(UnmanagedType.LPUTF8Str)] string path, out SerializedFileHandle handle);
 
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
@@ -270,13 +298,13 @@ public static class DllWrapper
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "UFS_GetRefTypeTypeTree")]
-    public static extern ReturnCode GetRefTypeTypeTree(SerializedFileHandle handle, [MarshalAs(UnmanagedType.LPStr)] string className,
-        [MarshalAs(UnmanagedType.LPStr)] string namespaceName, [MarshalAs(UnmanagedType.LPStr)] string assemblyName, out TypeTreeHandle typeTree);
+    public static extern ReturnCode GetRefTypeTypeTree(SerializedFileHandle handle, [MarshalAs(UnmanagedType.LPUTF8Str)] string className,
+        [MarshalAs(UnmanagedType.LPUTF8Str)] string namespaceName, [MarshalAs(UnmanagedType.LPUTF8Str)] string assemblyName, out TypeTreeHandle typeTree);
 
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,
         EntryPoint = "UFS_AddTypeTreeSourceFromFile")]
-    public static extern ReturnCode AddTypeTreeSourceFromFile([MarshalAs(UnmanagedType.LPStr)] string path, out long handle);
+    public static extern ReturnCode AddTypeTreeSourceFromFile([MarshalAs(UnmanagedType.LPUTF8Str)] string path, out long handle);
 
     [DllImport("UnityFileSystemApi",
         CallingConvention = CallingConvention.Cdecl,


### PR DESCRIPTION
## Summary

Fixes #14.

`UnityDataTool` threw `FileNotFoundException`/`IOException` when a path contained non-ASCII characters (Japanese, emoji, etc.), e.g. running `analyze` or `dump` from a directory like `テスト`. Commands that stay entirely in C# (such as `serialized-file`) worked fine, which pointed at the native interop layer.

The native `UnityFileSystemApi` expects `char*` paths encoded as **UTF-8** (on Windows it decodes them via `MultiByteToWideChar(CP_UTF8, …)` before `CreateFileW`; on macOS/Linux the bytes pass straight to the POSIX file APIs, where UTF-8 is the convention). But `DllWrapper` marshalled every path with `[MarshalAs(UnmanagedType.LPStr)]`, which is the system ANSI code page. On a non-Japanese Windows install, `テスト` has no ANSI representation and was converted to `?` before ever reaching native, so the file couldn't be found. `LPUTF8Str` is the platform-independent, universally-correct choice.

## Changes

- **`DllWrapper.cs`**: marshal path/string **inputs** to the native library as UTF-8.
  - `MountArchive`, `OpenFile`, `OpenSerializedFile`, `AddTypeTreeSourceFromFile`, `GetRefTypeTypeTree`: `LPStr` → `LPUTF8Str`.
  - `CreateArchive`: `outputFile` → `LPUTF8Str`; the two `char**` string arrays are marshalled to UTF-8 by hand (via `Marshal.StringToCoTaskMemUTF8`) since `LPUTF8Str` can't be used as an `LPArray` subtype. The public signature is unchanged.
  - Documented that the `StringBuilder`-based **outputs** (e.g. `GetArchiveNode`) only round-trip ASCII. These carry Unity-controlled internal archive/serialized-file names, which are always ASCII, so this is left as-is.

## Testing

- `dotnet test UnityFileSystem.Tests` — full suite green (435 passed, 10 pre-existing skips).
- Added `MountArchive_NonAsciiPath_ReturnsArchive` and `OpenFile_NonAsciiPath_ReadsExpectedData`, which copy test files into a temp directory whose directory and file names contain Japanese characters and open them through the native API. These would fail on Windows with the old ANSI marshalling.
- Manual end-to-end: reproduced the original scenario — `dump --stdout level0` from a `テスト` directory — which now succeeds where it previously threw.

Note: the bug was Windows-specific (only there does `LPStr` mean the lossy ANSI code page; .NET on macOS/Linux already marshals `LPStr` as UTF-8), so the new tests pass on all platforms and the macOS CI run validates that the change doesn't regress Unix.
